### PR TITLE
Add custom metrics to CloudWatch and push request uri.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,10 @@ libraryDependencies ++= {
     "io.spray"            %%  "spray-client"  % sprayV,
     "com.typesafe.akka"   %%  "akka-actor"    % akkaV,
     "com.typesafe.akka"   %%  "akka-slf4j"    % akkaV,
-    "ch.qos.logback"      %   "logback-classic" % "1.1.2")
+    "ch.qos.logback"      %   "logback-classic" % "1.1.2",
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
+    "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.24"
+  )
 }
 
 lazy val root = (project in file(".")).enablePlugins(

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ libraryDependencies ++= {
     "com.typesafe.akka"   %%  "akka-slf4j"    % akkaV,
     "ch.qos.logback"      %   "logback-classic" % "1.1.2",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
-    "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.24"
+    "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.39"
   )
 }
 

--- a/src/main/resources/DEV.conf
+++ b/src/main/resources/DEV.conf
@@ -1,1 +1,3 @@
 include "application"
+
+stage = "DEV"

--- a/src/main/resources/PROD.conf
+++ b/src/main/resources/PROD.conf
@@ -1,1 +1,3 @@
 include "application"
+
+stage = "PROD"

--- a/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
@@ -13,4 +13,6 @@ object Configuration {
     (proxyUri.scheme, proxyUri.authority.host.address, proxyUri.effectivePort)
   }
 
+  val stage: String = appConfig.getString("stage")
+
 }

--- a/src/main/scala/com/gu/subscriptions/cas/monitoring/CloudWatch.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/monitoring/CloudWatch.scala
@@ -1,0 +1,59 @@
+package com.gu.subscriptions.cas.monitoring
+
+import java.util.concurrent.Future
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.regions.{Region, ServiceAbbreviations}
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest}
+import com.typesafe.scalalogging.LazyLogging
+
+trait CloudWatch extends LazyLogging  {
+  val region: Region
+  val stage: String
+  val application : String
+
+  lazy val stageDimension = new Dimension().withName("Stage").withValue(stage)
+  def mandatoryDimensions:Seq[Dimension] = Seq(stageDimension)
+
+  lazy val cloudwatch = {
+    val client = new AmazonCloudWatchAsyncClient(new DefaultAWSCredentialsProviderChain)
+    client.setEndpoint(region.getServiceEndpoint(ServiceAbbreviations.CloudWatch))
+    client
+  }
+
+  trait LoggingAsyncHandler extends AsyncHandler[PutMetricDataRequest, Void]
+  {
+    def onError(exception: Exception)
+    {
+      logger.info(s"CloudWatch PutMetricDataRequest error: ${exception.getMessage}}")
+    }
+    def onSuccess(request: PutMetricDataRequest, result: Void )
+    {
+      logger.trace("CloudWatch PutMetricDataRequest - success")
+      CloudWatchHealth.hasPushedMetricSuccessfully = true
+    }
+  }
+
+  object LoggingAsyncHandler extends LoggingAsyncHandler
+
+
+  def put(name : String, count: Double, extraDimensions: Dimension*): Future[Void] = {
+    val metric =
+      new MetricDatum()
+        .withValue(count)
+        .withMetricName(name)
+        .withUnit("Count")
+        .withDimensions((mandatoryDimensions ++ extraDimensions): _*)
+
+    val request = new PutMetricDataRequest().
+      withNamespace(application).withMetricData(metric)
+
+    cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)
+  }
+}
+
+object CloudWatchHealth {
+  var hasPushedMetricSuccessfully = false
+}

--- a/src/main/scala/com/gu/subscriptions/cas/monitoring/Metrics.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/monitoring/Metrics.scala
@@ -1,0 +1,10 @@
+package com.gu.subscriptions.cas.monitoring
+
+import com.amazonaws.regions.{Region, Regions}
+import com.gu.subscriptions.cas.config.Configuration
+
+object Metrics extends CloudWatch {
+  val region = Region.getRegion(Regions.EU_WEST_1)
+  val stage = Configuration.stage
+  val application = "content-auth-proxy"
+}


### PR DESCRIPTION
Adds custome metrics to push to CloudWatch. This will allow us to count number of requests to the CAS service (and later the Zuora service). 

cc/ @rtyley 
