### PR TITLE
Add PushMetrics to the cfn policy

### DIFF
--- a/cloudformation/content-authorisation-proxy.cf.json
+++ b/cloudformation/content-authorisation-proxy.cf.json
@@ -142,6 +142,18 @@
                             "Resource": ["arn:aws:logs:*:*:*"]
                         }]
                     }
+                },
+                {
+                    "PolicyName": "PushMetrics",
+                    "PolicyDocument": {
+                        "Version": "2012-10-17",
+                        "Statement":[{
+                            "Effect":"Allow",
+                            "Action":["cloudwatch:PutMetricData"],
+                            "Resource":"*"
+                        }
+                        ]
+                    }
                 }]
             }
         },


### PR DESCRIPTION
As part of https://github.com/guardian/content-authorisation-proxy/pull/7 I missed updating the cloudformation script. This has now been applied to the stack.