### PR TITLE
Updating the proxy url to the legacy app 

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,1 +1,1 @@
-proxy = "https://content-auth.guardian.co.uk/"
+proxy = "https://cas-legacy.subscriptions.guardianapis.com/"


### PR DESCRIPTION
so that we can point conten-auth.guardian.co.uk to the proxy (and it doesn't call itself!).