### PR TITLE
Logging changes

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,1 +1,6 @@
 proxy = "https://content-auth.guardian.co.uk/"
+
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "INFO"
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,27 +3,20 @@
     <contextName>identity-oauth</contextName>
 
     <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/cas-proxy.log</file>
+        <file>logs/content-auth-proxy.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/identity-oauth.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+            <fileNamePattern>logs/content-auth-proxy.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%thread] %-5level %logger{36}:%line - %msg%n%xException{full}</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36}:%line - %msg%n%xException{full}</pattern>
+            <pattern>%date [%thread] %-5level %logger{36}:%line - %msg%n%xException{3}</pattern>
         </encoder>
     </appender>
 
     <root level="info">
         <appender-ref ref="LOGFILE"/>
-        <appender-ref ref="STDOUT"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
The logs were going to std.out so I've switched this to go to a log file. 

I've removed the some headers from the response from the request as Spray seems to ignore them and override it with its own headers. This causes a lot of warnings in the logs which is just noise.