### PR TITLE
Include /etc/gu/cas-proxy.conf in application.conf

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,3 +4,5 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   loglevel = "INFO"
 }
+
+include file("/etc/gu/cas-proxy.conf")

--- a/src/main/scala/com/gu/subscriptions/cas/bootstrap/CASService.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/bootstrap/CASService.scala
@@ -1,15 +1,16 @@
 package com.gu.subscriptions.cas.bootstrap
 
-import com.gu.subscriptions.cas.directives.{HealthCheckDirective, ProxyDirective}
+import com.gu.subscriptions.cas.directives.{CheckSentryErrors, HealthCheckDirective, ProxyDirective}
 import spray.routing._
 
 class CASService extends HttpServiceActor
   with ProxyDirective
-  with HealthCheckDirective {
+  with HealthCheckDirective
+  with CheckSentryErrors {
 
   override def actorRefFactory = context
 
   override implicit val actorSystem = context.system
 
-  override def receive = runRoute(healthCheck ~ proxyRoute)
+  override def receive = runRoute(healthCheck ~ proxyRoute ~ testSentryErrors)
 }

--- a/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
@@ -6,7 +6,6 @@ import spray.http.Uri
 
 
 object Configuration {
-  private val log = LoggerFactory.getLogger(getClass)
   private val appConfig = ConfigFactory.load()
 
   val EXPECTED_FIELDS = List(
@@ -15,14 +14,7 @@ object Configuration {
 
   val stage = appConfig.getString("stage")
 
-  val sentryDsn =
-    if (appConfig.hasPath("sentry.dsn")) {
-      log.info("Sentry DSN found, we will report errors to Sentry")
-      Some(appConfig.getString("sentry.dsn"))
-    } else {
-      if (stage == "PROD") log.error("Setting 'sentry.dsn' is blank! The app will not be able to report errors to Sentry")
-      None
-    }
+  val sentryDsn = Option(appConfig.getString("sentry.dsn"))
 
   val proxy = appConfig.getString("proxy")
 

--- a/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
@@ -15,15 +15,14 @@ object Configuration {
 
   val stage = appConfig.getString("stage")
 
-  val sentryDsn = (stage, appConfig.hasPath("sentry.dsn")) match {
-    case ("PROD", true) =>
+  val sentryDsn =
+    if (appConfig.hasPath("sentry.dsn")) {
+      log.info("Sentry DSN found, we will report errors to Sentry")
       Some(appConfig.getString("sentry.dsn"))
-    case ("PROD", false) =>
-      log.warn("Setting 'sentry.dsn' is blank! The app will not be able to report errors to Sentry")
+    } else {
+      if (stage == "PROD") log.error("Setting 'sentry.dsn' is blank! The app will not be able to report errors to Sentry")
       None
-    case _ =>
-      None
-  }
+    }
 
   val proxy = appConfig.getString("proxy")
 

--- a/src/main/scala/com/gu/subscriptions/cas/directives/CheckSentryErrors.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/CheckSentryErrors.scala
@@ -1,0 +1,12 @@
+package com.gu.subscriptions.cas.directives
+
+import spray.routing.{HttpService, Route}
+
+trait CheckSentryErrors { this: HttpService =>
+  val testSentryErrors: Route = get {
+    path("error") {
+      lazy val n = 1 / 0
+      complete(n.toString)
+    }
+  }
+}


### PR DESCRIPTION
- Include config file with Sentry credentials within the `application.conf` file.
- Also adds a temporary endpoint to test Sentry integration by triggering a divide by zero exception. We will remove it at the next deployment.

@rtyley @tudorraul 