### PR TITLE
Fix filename in cloudformation logger config

### DIFF
--- a/cloudformation/resources/conf/logger.conf
+++ b/cloudformation/resources/conf/logger.conf
@@ -1,8 +1,8 @@
 [general]
 state_file = /var/awslogs/agent-state
 
-[/subscriptions/logs/cas-proxy.log]
-file = /subscriptions/logs/cas-proxy.log
+[/subscriptions/logs/content-auth-proxy.log]
+file = /subscriptions/logs/content-auth-proxy.log
 log_group_name = CASProxyLogs-__STAGE
-log_stream_name = __DATE/{instance_id}/cas-proxy.log
+log_stream_name = __DATE/{instance_id}/content-auth-proxy.log
 datetime_format = %Y-%m-%d %H:%M-%S


### PR DESCRIPTION
Because of a filename change cloud-watch has stopped collecting cas-proxy logs since June the 3th. This fixes the config and should allow Cloudwatch to resume collecting our logs.