### PR TITLE
Metrics for the CAS legacy service

### DIFF
--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -4,8 +4,10 @@ import akka.actor.ActorSystem
 import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
+import com.amazonaws.regions.{Regions, Region}
+import com.gu.subscriptions.cas.config.Configuration
 import com.gu.subscriptions.cas.config.Configuration.{proxyHost, proxyPort, proxyScheme}
-import com.gu.subscriptions.cas.monitoring.Metrics
+import com.gu.subscriptions.cas.monitoring.{RequestMetrics, StatusMetrics}
 import spray.can.Http
 import spray.http.HttpHeaders.Host
 import spray.http.{HttpRequest, HttpResponse}
@@ -14,12 +16,14 @@ import spray.routing.{Directives, RequestContext}
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-trait ProxyDirective extends Directives {
+trait ProxyDirective extends Directives{
 
   implicit val actorSystem: ActorSystem
   implicit val timeout: Timeout = 1.seconds
 
   import actorSystem.dispatcher
+
+  val metrics = new CASMetrics(Configuration.stage)
 
   val proxyRoute =
     (path("subs") | path("auth")) {
@@ -36,10 +40,16 @@ trait ProxyDirective extends Directives {
     }
 
   def sendReceive(request: HttpRequest, followRedirect: Boolean = true): Future[HttpResponse] = {
-    Metrics.put(s"Request URI ${request.uri.toString()}", 1)
+    metrics.putRequest
     val excludeHeaders = Set("date", "content-type", "server", "content-length")
     (IO(Http) ? request).mapTo[HttpResponse].map { resp =>
+      metrics.putResponseCode(resp.status.intValue, "POST")
       resp.withHeaders(resp.headers.filterNot(header => excludeHeaders.contains(header.lowercaseName)))
     }
   }
+}
+
+class CASMetrics(val stage: String) extends StatusMetrics with RequestMetrics {
+  override val region: Region = Region.getRegion(Regions.EU_WEST_1)
+  override val application: String = "CAS-legacy"
 }

--- a/src/main/scala/com/gu/subscriptions/cas/monitoring/CloudWatch.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/monitoring/CloudWatch.scala
@@ -52,6 +52,10 @@ trait CloudWatch extends LazyLogging  {
 
     cloudwatch.putMetricDataAsync(request, LoggingAsyncHandler)
   }
+
+  def put(name: String, count: Double, responseMethod: String) {
+    put(name, count, new Dimension().withName("ResponseMethod").withValue(responseMethod))
+  }
 }
 
 object CloudWatchHealth {

--- a/src/main/scala/com/gu/subscriptions/cas/monitoring/Metrics.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/monitoring/Metrics.scala
@@ -1,10 +1,14 @@
 package com.gu.subscriptions.cas.monitoring
 
-import com.amazonaws.regions.{Region, Regions}
-import com.gu.subscriptions.cas.config.Configuration
+trait StatusMetrics extends CloudWatch {
+  def putResponseCode(status: Int, responseMethod: String) {
+    val statusClass = status / 100
+    put(s"${statusClass}XX-response-code", 1, responseMethod)
+  }
+}
 
-object Metrics extends CloudWatch {
-  val region = Region.getRegion(Regions.EU_WEST_1)
-  val stage = Configuration.stage
-  val application = "content-auth-proxy"
+trait RequestMetrics extends CloudWatch {
+  def putRequest {
+    put("request-count", 1)
+  }
 }


### PR DESCRIPTION
This allows us to factor out the 500 received from the legacy service from the ones CAS proxy returns.