### PR TITLE
Error handling

### DIFF
--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -6,17 +6,17 @@ import akka.pattern.ask
 import akka.util.Timeout
 import com.amazonaws.regions.{Region, Regions}
 import com.gu.subscriptions.cas.config.Configuration
-import com.gu.subscriptions.cas.config.Configuration.{proxyHost, proxyPort, proxyScheme}
 import com.gu.subscriptions.cas.directives.ZuoraDirective._
 import com.gu.subscriptions.cas.model.SubscriptionRequest
 import com.gu.subscriptions.cas.model.json.ModelJsonProtocol._
 import com.gu.subscriptions.cas.monitoring.{RequestMetrics, StatusMetrics}
 import com.gu.subscriptions.cas.service.{SubscriptionService, ZuoraSubscriptionService}
 import spray.can.Http
-import spray.http.HttpHeaders.Host
+import spray.http.HttpHeaders._
 import spray.http.{HttpRequest, HttpResponse}
+import spray.httpx.ResponseTransformation._
 import spray.httpx.SprayJsonSupport._
-import spray.routing.{Directives, RequestContext, Route}
+import spray.routing.{Directives, Route}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -26,29 +26,40 @@ trait ProxyDirective extends Directives with ErrorRoute {
   implicit val actorSystem: ActorSystem
   lazy val subscriptionService: SubscriptionService = ZuoraSubscriptionService
 
-  lazy val casRoute = {
+  lazy val proxyHost = Configuration.proxyHost
+  lazy val proxyPort = Configuration.proxyPort
+  lazy val proxyScheme = Configuration.proxyScheme
+
+  def proxyRequest(in: HttpRequest): HttpRequest =
+    in.copy(
+      uri = in.uri.withHost(proxyHost).withPort(proxyPort).withScheme(proxyScheme),
+      headers = in.headers.map {
+        case Host(_, _) => Host(proxyHost)
+        case header => header
+      }
+    )
+
+  def logProxyResp(metrics: CASMetrics): HttpResponse => HttpResponse = { resp =>
+    metrics.putResponseCode(resp.status.intValue, "POST")
+    resp
+  }
+
+  val filterHeaders: HttpResponse => HttpResponse = resp =>
+    resp.withHeaders(resp.headers.filter {
+      case Date(_) | `Content-Type`(_) | Server(_) | `Content-Length`(_) => false
+      case _ => true
+    })
+
+  lazy val casRoute: Route = {
     implicit val timeout: Timeout = 1.seconds
     val metrics = new CASMetrics(Configuration.stage)
 
     def sendReceive(request: HttpRequest, followRedirect: Boolean = true): Future[HttpResponse] = {
       metrics.putRequest
-      val excludeHeaders = Set("date", "content-type", "server", "content-length")
-      (IO(Http) ? request).mapTo[HttpResponse].map { resp =>
-        metrics.putResponseCode(resp.status.intValue, "POST")
-        resp.withHeaders(resp.headers.filterNot(header => excludeHeaders.contains(header.lowercaseName)))
-      }
+      (IO(Http) ? request).mapTo[HttpResponse].map(logProxyResp(metrics) ~> filterHeaders)
     }
 
-    { ctx: RequestContext =>
-      val newRequest = ctx.request.copy(
-        uri = ctx.request.uri.withHost(proxyHost).withPort(proxyPort).withScheme(proxyScheme),
-        headers = ctx.request.headers.map { header =>
-          if (header.name.toLowerCase == "host") Host(proxyHost)
-          else header
-        })
-
-      ctx.complete(sendReceive(newRequest))
-    }
+    ctx => ctx.complete(sendReceive(proxyRequest(ctx.request)))
   }
 
   val authRoute: Route = (path("auth") & post)(casRoute)

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ResponseCodeTransformer.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ResponseCodeTransformer.scala
@@ -6,7 +6,7 @@ import spray.http.HttpResponse
 import spray.http.StatusCodes._
 import spray.json._
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 object ResponseCodeTransformer {
   /**

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ResponseCodeTransformer.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ResponseCodeTransformer.scala
@@ -1,0 +1,43 @@
+package com.gu.subscriptions.cas.directives
+
+import com.gu.cas.CAS.CASError
+import com.gu.subscriptions.cas.model.json.ModelJsonProtocol._
+import spray.http.HttpResponse
+import spray.http.StatusCodes._
+import spray.json._
+
+import scala.util.{Failure, Success, Try}
+
+object ResponseCodeTransformer {
+  /**
+   * Change the response code that is returned by the call to CAS.
+   * This is necessary because in some cases CAS sends a 200 response
+   * containing an error, making the API misleading.
+   * The error codes are defined there:
+   * https://github.com/guardian/content-authorisation/blob/master/content-authorisation/src/main/resources/conf/global.properties
+   */
+
+  val badRequestCodes = Seq(-40, -50, -80)
+  case class BadRequestCode(code: Int)
+  object BadRequestCode {
+    def unapply(code: Int) = if (badRequestCodes.contains(code)) Some(BadRequestCode(code)) else None
+  }
+
+  val unauthorizedCodes = Seq(-60, -70, -90, -100, -110, -120)
+  case class UnauthorizedCode(code: Int)
+  object UnauthorizedCode {
+    def unapply(code: Int) = if (unauthorizedCodes.contains(code)) Some(UnauthorizedCode(code)) else None
+  }
+
+  val changeResponseCode: HttpResponse => HttpResponse = resp =>
+    Try {
+      resp.entity.asString.parseJson.convertTo[CASError]
+    } match {
+      // Caveat: A malformed json payload send to the /auth endpoint will result in an HTML 404 response by
+      // the CAS server so won't be caught in the pattern match below.
+      case Success(CASError(_, BadRequestCode(_))) => resp.copy(status = BadRequest)
+      case Success(CASError(_, UnauthorizedCode(_))) => resp.copy(status = Unauthorized)
+      case Success(_) => resp.copy(status = InternalServerError)
+      case Failure(_) => resp
+    }
+}

--- a/src/main/scala/com/gu/subscriptions/cas/model/json/ModelJsonProtocol.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/model/json/ModelJsonProtocol.scala
@@ -1,18 +1,41 @@
 package com.gu.subscriptions.cas.model.json
 
+import com.gu.cas.CAS.CASError
 import com.gu.subscriptions.cas.model.{SubscriptionRequest, SubscriptionExpiration}
 import spray.json._
 
 object ModelJsonProtocol extends DefaultJsonProtocol {
-  implicit object SubscriptionExpirationProtocol extends RootJsonFormat[SubscriptionExpiration] {
+  implicit object SubscriptionExpirationProtocol extends RootJsonWriter[SubscriptionExpiration] {
     override def write(sub: SubscriptionExpiration): JsValue = JsObject(
       "expiry" -> JsObject(
         "expiryType" -> JsString(sub.expiryType),
         "expiryDate" -> JsString(sub.expiryDate.toString("YYYY-MM-dd"))
     ))
-
-    override def read(json: JsValue): SubscriptionExpiration = ??? // not needed
   }
 
   implicit val subsRequestFormat = jsonFormat2(SubscriptionRequest)
+
+  case class CASErrorInternal(message: String, code: Int)
+
+  implicit val casErrorFormat = jsonFormat2(CASErrorInternal)
+
+  implicit object CASErrorProtocol extends RootJsonFormat[CASError] {
+    override def write(error: CASError): JsValue = JsObject(
+      "error" -> CASErrorInternal(error.message, error.code).toJson
+    )
+
+    //In the CASError definition, deserialization code uses play.json
+    override def read(json: JsValue): CASError = json match {
+      case JsObject(map) =>
+        map.get("error") match {
+          case Some(obj) =>
+            val error = obj.convertTo[CASErrorInternal]
+            CASError(error.message, error.code)
+          case None =>
+            deserializationError("Expected an error field")
+        }
+
+      case _ => deserializationError("Expected a json object")
+    }
+  }
 }

--- a/src/main/scala/com/gu/subscriptions/cas/model/json/ModelJsonProtocol.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/model/json/ModelJsonProtocol.scala
@@ -15,27 +15,8 @@ object ModelJsonProtocol extends DefaultJsonProtocol {
 
   implicit val subsRequestFormat = jsonFormat2(SubscriptionRequest)
 
-  case class CASErrorInternal(message: String, code: Int)
+  case class CASErrorWrapper(error: CASError)
 
-  implicit val casErrorFormat = jsonFormat2(CASErrorInternal)
-
-  implicit object CASErrorProtocol extends RootJsonFormat[CASError] {
-    override def write(error: CASError): JsValue = JsObject(
-      "error" -> CASErrorInternal(error.message, error.code).toJson
-    )
-
-    //In the CASError definition, deserialization code uses play.json
-    override def read(json: JsValue): CASError = json match {
-      case JsObject(map) =>
-        map.get("error") match {
-          case Some(obj) =>
-            val error = obj.convertTo[CASErrorInternal]
-            CASError(error.message, error.code)
-          case None =>
-            deserializationError("Expected an error field")
-        }
-
-      case _ => deserializationError("Expected a json object")
-    }
-  }
+  implicit val casErrorFormat = jsonFormat2(CASError)
+  implicit val casErrorWrapperFormat = jsonFormat1(CASErrorWrapper)
 }

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
@@ -28,7 +28,7 @@ class ProxyDirectiveSpec extends FreeSpec
   val expiration = SubscriptionExpiration(DateTime.now())
 
   override lazy val casRoute: Route = complete(handledByCAS)
-  override lazy val proxyHost = "www.example-proxy.com"
+  override lazy val proxyHost = "example-proxy"
   override lazy val proxyPort = 443
   override lazy val proxyScheme = "https"
 
@@ -86,12 +86,12 @@ class ProxyDirectiveSpec extends FreeSpec
 
     "proxyRequest" - {
       val req = HttpRequest(
-        uri = Uri("http://www.example.com/endpoint"),
+        uri = Uri("http://example/endpoint"),
         headers = List(Host("www.example.com"), fooHeader)
       )
 
       "updates the URI with proxy info" in {
-        assertResult(Uri("https://www.example-proxy.com:443/endpoint"))(proxyRequest(req).uri)
+        assertResult(Uri("https://example-proxy:443/endpoint"))(proxyRequest(req).uri)
       }
 
       "updates the host header with the proxy host" in {

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
@@ -5,7 +5,8 @@ import com.gu.subscriptions.cas.model.{SubscriptionExpiration, SubscriptionReque
 import com.gu.subscriptions.cas.service.SubscriptionService
 import org.joda.time.DateTime
 import org.scalatest.FreeSpec
-import spray.http.HttpEntity
+import spray.http.HttpHeaders._
+import spray.http._
 import spray.http.MediaTypes.`application/json`
 import spray.json._
 import spray.routing.{HttpService, Route}
@@ -27,6 +28,9 @@ class ProxyDirectiveSpec extends FreeSpec
   val expiration = SubscriptionExpiration(DateTime.now())
 
   override lazy val casRoute: Route = complete(handledByCAS)
+  override lazy val proxyHost = "www.example-proxy.com"
+  override lazy val proxyPort = 443
+  override lazy val proxyScheme = "https"
 
   override lazy val subscriptionService = new SubscriptionService {
     override def verifySubscriptionExpiration(subscriptionName: String, postcode: String) =
@@ -73,6 +77,43 @@ class ProxyDirectiveSpec extends FreeSpec
         Post("/subs", req) ~> inJson(subsRoute) ~> check {
           assertResult(BadRequest)(status)
         }
+      }
+    }
+  }
+
+  "proxying to CAS" - {
+    val fooHeader = RawHeader("foo", "bar")
+
+    "proxyRequest" - {
+      val req = HttpRequest(
+        uri = Uri("http://www.example.com/endpoint"),
+        headers = List(Host("www.example.com"), fooHeader)
+      )
+
+      "updates the URI with proxy info" in {
+        assertResult(Uri("https://www.example-proxy.com:443/endpoint"))(proxyRequest(req).uri)
+      }
+
+      "updates the host header with the proxy host" in {
+        assertResult(
+          List(Host(proxyHost), fooHeader)
+        )(
+          proxyRequest(req).headers
+        )
+      }
+    }
+
+    "filterHeaders" - {
+      "filters some headers out of the proxy response" in {
+        val resp = HttpResponse(headers = List(
+          Date(spray.http.DateTime.now),
+          `Content-Type`(`application/json`),
+          Server("Nginx"),
+          `Content-Length`(1024L),
+          fooHeader
+        ))
+
+        assertResult(List(fooHeader))(filterHeaders(resp).headers)
       }
     }
   }

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ResponseCodeTransformerSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ResponseCodeTransformerSpec.scala
@@ -12,7 +12,7 @@ import spray.http.{HttpEntity, HttpResponse}
 class ResponseCodeTransformerSpec extends FreeSpec {
   "The response code is changed" - {
     def response(code: Int): HttpResponse = {
-      val error = CASError("error message", code)
+      val error = CASErrorWrapper(CASError("error message", code))
       HttpResponse(entity = HttpEntity(`application/json`, error.toJson.toString()))
     }
 

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ResponseCodeTransformerSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ResponseCodeTransformerSpec.scala
@@ -1,0 +1,39 @@
+package com.gu.subscriptions.cas.directives
+import com.gu.cas.CAS.CASError
+import com.gu.subscriptions.cas.model.json.ModelJsonProtocol._
+import spray.http.MediaTypes.`application/json`
+import spray.http.StatusCodes._
+import spray.json._
+import ResponseCodeTransformer._
+
+import org.scalatest.FreeSpec
+import spray.http.{HttpEntity, HttpResponse}
+
+class ResponseCodeTransformerSpec extends FreeSpec {
+  "The response code is changed" - {
+    def response(code: Int): HttpResponse = {
+      val error = CASError("error message", code)
+      HttpResponse(entity = HttpEntity(`application/json`, error.toJson.toString()))
+    }
+
+    "when there is a bad request" in {
+      val resp = response(-40)
+      assertResult(BadRequest)(changeResponseCode(resp).status)
+    }
+
+    "when there is an unauthorized request" in {
+      val resp = response(-60)
+      assertResult(Unauthorized)(changeResponseCode(resp).status)
+    }
+
+    "when there is an unknown error" in {
+      val resp = response(100)
+      assertResult(InternalServerError)(changeResponseCode(resp).status)
+    }
+  }
+
+  "The response is not changed when an error cannot be extracted from the entity" in {
+    val resp = HttpResponse()
+    assertResult(resp)(changeResponseCode(resp))
+  }
+}

--- a/src/test/scala/com/gu/subscriptions/cas/model/json/CASErrorExpirationProtocolSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/model/json/CASErrorExpirationProtocolSpec.scala
@@ -7,7 +7,7 @@ import ModelJsonProtocol._
 
 class CASErrorExpirationProtocolSpec extends FreeSpec {
   "For CASError" - {
-    val error = CASError("message", -1)
+    val error = CASErrorWrapper(CASError("message", -1))
     val json =
       """
         |{ "error": { "message": "message", "code": -1 } }
@@ -18,7 +18,7 @@ class CASErrorExpirationProtocolSpec extends FreeSpec {
     }
 
     "handles deserialization" in {
-      assertResult(error)(json.parseJson.convertTo[CASError])
+      assertResult(error)(json.parseJson.convertTo[CASErrorWrapper])
     }
   }
 }

--- a/src/test/scala/com/gu/subscriptions/cas/model/json/CASErrorExpirationProtocolSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/model/json/CASErrorExpirationProtocolSpec.scala
@@ -1,0 +1,24 @@
+package com.gu.subscriptions.cas.model.json
+
+import com.gu.cas.CAS.CASError
+import org.scalatest.FreeSpec
+import spray.json._
+import ModelJsonProtocol._
+
+class CASErrorExpirationProtocolSpec extends FreeSpec {
+  "For CASError" - {
+    val error = CASError("message", -1)
+    val json =
+      """
+        |{ "error": { "message": "message", "code": -1 } }
+      """.stripMargin
+
+    "handles serialization" in {
+      assertResult(json.parseJson)(error.toJson)
+    }
+
+    "handles deserialization" in {
+      assertResult(error)(json.parseJson.convertTo[CASError])
+    }
+  }
+}


### PR DESCRIPTION
This is another attempt at the PR https://github.com/guardian/content-authorisation-proxy/pull/22/files
which aimed at testing the request and response transformation while proxying.

Also adds the correct response codes after proxying to CAS, when possible. This is due to CAS sometimes sending 200 responses even in the presence of errors, relying on an error code mapping defined in https://github.com/guardian/content-authorisation/blob/master/content-authorisation/src/main/resources/conf/global.properties

This previously failed due to the casRoute function in ProxyDirective

`ctx => complete(...)`

instead of

`ctx => ctx.complete(...)`