### PR TITLE
Return 'sub' for the expiry type, just like legacy CAS

### DIFF
--- a/src/main/scala/com/gu/subscriptions/cas/model/SubscriptionExpiration.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/model/SubscriptionExpiration.scala
@@ -1,4 +1,4 @@
 package com.gu.subscriptions.cas.model
 import org.joda.time.DateTime
 
-case class SubscriptionExpiration(expiryDate: DateTime, expiryType: String = "subs")
+case class SubscriptionExpiration(expiryDate: DateTime, expiryType: String = "sub")


### PR DESCRIPTION
https://trello.com/c/LKZZGejH/99-incorrect-sub-type-returned-from-cas-proxy-for-direct-debit-subscriptions

With this change, `expiryType` is now `sub`, as expected by Guardian IOS mobile apps.

```
$ curl -H "Content-Type:application/json; charset=UTF-8" -d "{ \"appId\" : \"touchpoint-membership\", \"deviceId\" : \"ROBERTO MADE THIS UP\", \"subscriberd\" : \"A-S00013340\", \"password\" : \"E8123\"}" http://localhost:9300/subs
{
  "expiry": {
    "expiryType": "sub",
    "expiryDate": "2016-08-08"
  }
}
```

cc @tudorraul @TesterSpike 