### PR TITLE
Fix incorrect cancellation date returned by CAS proxy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.39",
-    "com.gu" %% "membership-common" % "0.78",
+    "com.gu" %% "membership-common" % "0.79",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/src/main/scala/com/gu/subscriptions/cas/service/ZuoraSubscriptionService.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/service/ZuoraSubscriptionService.scala
@@ -1,6 +1,7 @@
 package com.gu.subscriptions.cas.service
 
 import com.amazonaws.regions.{Region, Regions}
+import com.gu.membership.util.Timing
 import com.gu.membership.zuora.soap.Zuora._
 import com.gu.membership.zuora.soap._
 import com.gu.monitoring.{CloudWatch, ZuoraMetrics}
@@ -96,9 +97,11 @@ object ZuoraClient extends ZuoraApi with ZuoraClient {
     request(Login(apiConfig)))
 
   def queryForSubscription(subscriptionName: String): Future[Zuora.Subscription] =
-    query[Zuora.Subscription](s"Name='$subscriptionName'")
-      .map(_.sortWith(_.version > _.version).headOption
+    Timing.record(metrics, "queryForSubscription") {
+      query[Zuora.Subscription](s"Name='$subscriptionName'")
+        .map(_.sortWith(_.version > _.version).headOption
         .getOrElse(throw new ZuoraQueryException(s"Subscription not found '$subscriptionName'")))
+    }
 
   def queryForProduct(id: String): Future[Zuora.Product] =
     queryOne[Zuora.Product](s"Id='$id'")

--- a/src/main/scala/com/gu/subscriptions/cas/service/ZuoraSubscriptionService.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/service/ZuoraSubscriptionService.scala
@@ -94,7 +94,7 @@ object ZuoraClient extends ZuoraApi with ZuoraClient {
     request(Login(apiConfig)))
 
   def queryForSubscription(subscriptionId: String): Future[Zuora.Subscription] =
-    queryOne[Zuora.Subscription](s"Name='$subscriptionId'")
+    query[Zuora.Subscription](s"Name='$subscriptionId'").map(_.sortWith(_.version > _.version).head)
 
   def queryForProduct(id: String): Future[Zuora.Product] =
     queryOne[Zuora.Product](s"Id='$id'")


### PR DESCRIPTION
Zuora will create an expired record for the subscription every time there is a change to the subscription which will hold the old data.  We should filter these records out when determining the subscription date.

This change ensures we consider only the latest version of a subscription to infer it's cancellation date.