### PR TITLE
Add Zuora readiness check as part of healthcheck

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.39",
-    "com.gu" %% "membership-common" % "0.82",
+    "com.gu" %% "membership-common" % "0.85",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ErrorRoute.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ErrorRoute.scala
@@ -32,4 +32,12 @@ trait ErrorRoute {
         entity = errorMsg("Internal server error")
       )
     )
+
+  val serviceUnavailableError: Route =
+    complete(
+      HttpResponse(
+        status = StatusCodes.ServiceUnavailable,
+        entity = errorMsg("Service Unavailable. Please try again later")
+      )
+    )
 }

--- a/src/main/scala/com/gu/subscriptions/cas/directives/HealthCheckDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/HealthCheckDirective.scala
@@ -1,18 +1,28 @@
 package com.gu.subscriptions.cas.directives
 
 import com.gu.subscriptions.cas.config.Configuration.nullSettings
+import com.gu.subscriptions.cas.service.zuora.ZuoraSubscriptionService
+import com.typesafe.scalalogging.LazyLogging
 import spray.http.MediaTypes._
 import spray.routing.{HttpService, Route}
 
-trait HealthCheckDirective {this: HttpService =>
+trait HealthCheckDirective extends LazyLogging with ErrorRoute {this: HttpService =>
   val healthCheck: Route =
-    get {
-      path("healthcheck") {
-        respondWithMediaType(`application/json`) {
+    (get & path("healthcheck") & respondWithMediaType(`application/json`)) {
+      // Make sure that the inner route gets reevaluated each time, as the Zuora service availability changes
+      dynamic {
+        {
           if (nullSettings.nonEmpty) {
             throw new RuntimeException(s"Configuration keys not found: '$nullSettings'")
           }
-          complete( s"""{ "status": "ok" , "gitCommitId": "${app.BuildInfo.gitCommitId}" }""")
+
+          if (!ZuoraSubscriptionService.isReady) {
+            logger.warn("Service not ready yet")
+            serviceUnavailableError
+          } else {
+            complete(s"""{ "status": "ok" , "gitCommitId": "${app.BuildInfo.gitCommitId}" }""")
+          }
+
         }
       }
     }

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -5,7 +5,6 @@ import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
 import com.amazonaws.regions.{Region, Regions}
-import com.gu.membership.zuora.soap.Zuora.Subscription
 import com.gu.subscriptions.cas.config.Configuration
 import com.gu.subscriptions.cas.directives.ResponseCodeTransformer._
 import com.gu.subscriptions.cas.directives.ZuoraDirective._

--- a/src/main/scala/com/gu/subscriptions/cas/service/zuora/ZuoraSubscriptionService.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/service/zuora/ZuoraSubscriptionService.scala
@@ -6,7 +6,6 @@ import com.gu.membership.zuora.soap.Zuora._
 import com.gu.membership.zuora.soap._
 import com.gu.monitoring.{CloudWatch, ZuoraMetrics}
 import com.gu.subscriptions.cas.config.Configuration
-import com.gu.subscriptions.cas.model.SubscriptionRequest
 import com.gu.subscriptions.cas.service.SubscriptionService
 import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.DateTime
@@ -24,6 +23,8 @@ class ZuoraSubscriptionService(zuoraClient: ZuoraClient,
 
     (postcodeA, postcodeB) => format(postcodeA) == format(postcodeB)
   }
+
+  def isReady: Boolean = zuoraClient.isReady
 
   private def knownProductCheck(subscription: Subscription): Future[Boolean] =
     for {
@@ -100,6 +101,8 @@ trait ZuoraClient {
   def queryForProduct(id: String): Future[Product]
 
   def updateSubscription(subscriptionId: String, fields: (String, String)*): Future[UpdateResult]
+
+  def isReady: Boolean
 }
 
 object ZuoraClient extends ZuoraClient {
@@ -142,4 +145,6 @@ object ZuoraClient extends ZuoraClient {
   def updateSubscription(subscriptionId: String, fields: (String, String)*): Future[UpdateResult] = {
     api.authenticatedRequest[UpdateResult](Update(subscriptionId, "Subscription", fields))
   }
+
+  override def isReady: Boolean = api.isReady
 }

--- a/src/test/scala/com/gu/subscriptions/cas/service/ZuoraSubscriptionServiceTest.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/service/ZuoraSubscriptionServiceTest.scala
@@ -1,13 +1,10 @@
 package com.gu.subscriptions.cas.service
 
-import java.util.concurrent.{Callable, FutureTask}
-
 import com.amazonaws.regions.{AwsFakes, Region}
-import com.amazonaws.services.cloudwatch.model.Dimension
 import com.gu.membership.zuora.soap.Zuora._
 import com.gu.monitoring.CloudWatch
-import com.gu.subscriptions.cas.service.zuora.{ZuoraSubscriptionService, ZuoraClient, ZuoraSubscriptionService$$}
-import org.scalatest.{Matchers, FlatSpec}
+import com.gu.subscriptions.cas.service.zuora.{ZuoraClient, ZuoraSubscriptionService}
+import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.Future
 
@@ -22,6 +19,7 @@ class ZuoraSubscriptionServiceTest extends FlatSpec with Matchers {
     override def queryForSubscription(subscriptionId: String): Future[Subscription] = ???
     override def queryForSubscriptionOpt(subscriptionName: String): Future[Option[Subscription]] = ???
     override def updateSubscription(subscriptionId: String, fields: (String, String)*): Future[UpdateResult] = ???
+    override def isReady: Boolean = true
   }
 
   private val cloudWatch = new CloudWatch {


### PR DESCRIPTION
This is needed as part of the fix for https://trello.com/c/L4RKJH74/153-fix-the-cas-proxy

We think that it was due to the Zuora client not being fully initialised. This includes a Zuora service readiness check as part of the healthcheck.