### PR TITLE
Updated the cloud formation certificate name

### DIFF
--- a/cloudformation/content-authorisation-proxy.cf.json
+++ b/cloudformation/content-authorisation-proxy.cf.json
@@ -33,8 +33,8 @@
         "CollectorDomainName": {
             "PROD": {
                 "HostedZoneName": "subscriptions.guardianapis.com.",
-                "DomainName": "cas-proxy.subscriptions.guardianapis.com.",
-                "CertificateName": "sites.guardian.co.uk"
+                    "DomainName": "cas-proxy.subscriptions.guardianapis.com.",
+                "CertificateName": "star.subscriptions.guardianapis.com"
             }
         }
     },


### PR DESCRIPTION
A new certificate has been issued for the cas proxy and cas legecy ELBs to use, the cert informaiton can be found https://trello.com/c/G5T24UEA/146-update-ssl-certificates-for-cas-legacy-proxy-servers this change is simply to update the cloud formation config to use the correct certificate.  