### PR TITLE
Membership common depending on play Akka system

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.39",
-    "com.gu" %% "membership-common" % "0.88",
+    "com.gu" %% "membership-common" % "0.89-SNAPSHOT",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.39",
-    "com.gu" %% "membership-common" % "0.89-SNAPSHOT",
+    "com.gu" %% "membership-common" % "0.89",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
@@ -2,16 +2,15 @@ package com.gu.subscriptions.cas.config
 
 import com.amazonaws.regions.{Region, Regions}
 import com.gu.membership.zuora.ZuoraApiConfig
-import com.gu.membership.zuora.soap.Client
 import com.gu.monitoring.{CloudWatch, ServiceMetrics}
-import com.gu.subscriptions.cas.config.Configuration.{appConfig, appName, system, stage => appStage}
+import com.gu.subscriptions.cas.config.Configuration.{appConfig, appName, stage => appStage}
 
 object Zuora {
-  private val zuoraConfig = appConfig.getConfig("touchpoint.backend.environments").getConfig(appStage)
-  private val apiConfig: ZuoraApiConfig = ZuoraApiConfig.from(zuoraConfig, appStage)
 
-  val metrics = new ServiceMetrics(appStage, appName, "Zuora")
-  val api = new Client(apiConfig, metrics, system)
+  private val zuoraConfig = appConfig.getConfig("touchpoint.backend.environments").getConfig(appStage)
+  val apiConfig: ZuoraApiConfig = ZuoraApiConfig.from(zuoraConfig, appStage)
+  val metrics = new ServiceMetrics(appStage, appName, "zuora-soap-client")
+
   val cloudWatch = new CloudWatch {
     override val region: Region = Region.getRegion(Regions.EU_WEST_1)
     override val application: String = appName


### PR DESCRIPTION
CAS proxy is a spray app and there were some dependencies on a play akka context in membership common, therefore had to bump the version number to the latest common release and moved the zuora client out of configuration namespace. 