### PR TITLE
Update our Cloudformation to use the correct SSL certificate

### DIFF
--- a/cloudformation/content-authorisation-proxy.cf.json
+++ b/cloudformation/content-authorisation-proxy.cf.json
@@ -34,7 +34,7 @@
             "PROD": {
                 "HostedZoneName": "subscriptions.guardianapis.com.",
                     "DomainName": "cas-proxy.subscriptions.guardianapis.com.",
-                "CertificateName": "star.subscriptions.guardianapis.com"
+                "CertificateName": "sites.guardian.co.uk"
             }
         }
     },


### PR DESCRIPTION
I've also created a RunScope test specifically for testing that the cert is valid:

https://www.runscope.com/radar/f862w29p8z5f/269ef569-b843-4d73-816b-1c2a519e4354/overview

See also:

https://trello.com/c/G5T24UEA/124-update-ssl-certificates-for-cas-legacy-proxy-servers

cc @chrisjowen @davidfurey 