### PR TITLE
Switch cas proxy url

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,6 @@ mappings in Universal ++= NativePackagerHelper.contentOf("cloudformation/resourc
 
 riffRaffPackageType := (packageBin in config("universal")).value
 
-addCommandAlias("devrun", "re-start --- -Dconfig.resource=DEV.conf ")
+addCommandAlias("devrun", "re-start --- -Dconfig.resource=DEV.conf")
 
 Revolver.settings

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,6 @@ mappings in Universal ++= NativePackagerHelper.contentOf("cloudformation/resourc
 
 riffRaffPackageType := (packageBin in config("universal")).value
 
-addCommandAlias("devrun", "re-start --- -Dconfig.resource=DEV.conf")
+addCommandAlias("devrun", "re-start --- -Dconfig.resource=DEV.conf ")
 
 Revolver.settings

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,4 +1,5 @@
 proxy = "https://cas-legacy.subscriptions.guardianapis.com/"
+proxyNew = "http://subs-cas-CASLegac-ZWI0H7Z9JY8T-1440512801.eu-west-1.elb.amazonaws.com/public/"
 
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 proxy = "https://cas-legacy.subscriptions.guardianapis.com/"
-proxyNew = "http://subs-cas-CASLegac-ZWI0H7Z9JY8T-1440512801.eu-west-1.elb.amazonaws.com/public/"
+proxyNew = "http://subs-cas-CASLegac-ZWI0H7Z9JY8T-1440512801.eu-west-1.elb.amazonaws.com/public"
 
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 proxy = "https://cas-legacy.subscriptions.guardianapis.com/"
-proxyNew = "http://subs-cas-CASLegac-ZWI0H7Z9JY8T-1440512801.eu-west-1.elb.amazonaws.com/public"
+proxyNew = "http://subs-cas-CASLegac-ZWI0H7Z9JY8T-1440512801.eu-west-1.elb.amazonaws.com/"
 
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]

--- a/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
@@ -2,7 +2,6 @@ package com.gu.subscriptions.cas.config
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
-import spray.http.Uri
 
 import scala.collection.JavaConversions._
 import scala.util.Try
@@ -22,11 +21,9 @@ object Configuration {
   val sentryDsn = Try(appConfig.getString("sentry.dsn"))
 
   val proxy = appConfig.getString("proxy")
+  val proxyNew = appConfig.getString("proxyNew")
 
-  val (proxyScheme, proxyHost, proxyPort):(String,String,Int) = {
-    val proxyUri = Uri(proxy)
-    (proxyUri.scheme, proxyUri.authority.host.address, proxyUri.effectivePort)
-  }
+
 
   val nullSettings = EXPECTED_FIELDS.filter(appConfig.getString(_) == null)
 

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -48,7 +48,7 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
       (proxyUri.scheme, proxyUri.authority.host.address, proxyUri.effectivePort, proxyUri.path)
     }
     in.copy(
-      uri = in.uri.withHost(proxyHost).withPort(proxyPort).withScheme(proxyScheme).withPath(Uri.Path(proxyPath.toString() + in.uri.path.toString())),
+      uri = in.uri.withHost(proxyHost).withPort(proxyPort).withScheme(proxyScheme),
       headers = in.headers.map {
         case Host(_, _) => Host(proxyHost)
         case header => header
@@ -88,7 +88,7 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
       ctx.complete(casResponse)
 
       val uri: Uri = request.uri
-      val isSubsRequest = uri.path != null &&
+      val isSubsRequest = request.uri.path != null &&
         uri.path.toString().contains("/subs")
 
       if (isSubsRequest) compareSubscriptionResponses(request, casResponse, metrics)

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -40,7 +40,7 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
     })
 
   def connectorFromUrl(proxyUri: Uri) = {
-    HostConnectorSetup(proxyUri.authority.host.address, proxyUri.effectivePort, sslEncryption = true)
+    HostConnectorSetup(proxyUri.authority.host.address, proxyUri.effectivePort, sslEncryption = proxyUri.scheme.toLowerCase().equals("https"))
   }
 
   def createProxyRequest(in: HttpRequest, proxyUri: Uri) = {

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -13,10 +13,11 @@ import com.gu.subscriptions.cas.model.{SubscriptionExpiration, SubscriptionReque
 import com.gu.subscriptions.cas.monitoring.{RequestMetrics, StatusMetrics}
 import com.gu.subscriptions.cas.service.SubscriptionService
 import com.gu.subscriptions.cas.service.zuora.ZuoraSubscriptionService
+import com.typesafe.scalalogging.LazyLogging
 import spray.can.Http
 import spray.can.Http.HostConnectorSetup
 import spray.http.HttpHeaders._
-import spray.http.{HttpRequest, HttpResponse}
+import spray.http.{HttpRequest, HttpResponse, Uri}
 import spray.httpx.ResponseTransformation._
 import spray.httpx.SprayJsonSupport._
 import spray.routing.{Directives, Route}
@@ -25,27 +26,38 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-trait ProxyDirective extends Directives with ErrorRoute {
+trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
 
   implicit val actorSystem: ActorSystem
-  implicit val timeout: Timeout = 1.seconds
-
+  implicit val timeout: Timeout = 2.seconds
   lazy val io: ActorRef = IO(Http)
   lazy val subscriptionService: SubscriptionService = ZuoraSubscriptionService
-  lazy val proxyHost = Configuration.proxyHost
-  lazy val proxyPort = Configuration.proxyPort
-  lazy val proxyScheme = Configuration.proxyScheme
 
-  def proxyRequest(in: HttpRequest): HttpRequest =
-    in.copy(
-      uri = in.uri.withHost(proxyHost).withPort(proxyPort).withScheme(proxyScheme),
+
+  def proxyRequest(in: HttpRequest, proxy: String): Future[HttpResponse] = {
+    val metrics = new CASMetrics(Configuration.stage)
+    val (proxyScheme, proxyHost, proxyPort, proxyPath) = {
+      val proxyUri = Uri(proxy)
+      (proxyUri.scheme, proxyUri.authority.host.address, proxyUri.effectivePort, proxyUri.path)
+    }
+
+    val request = in.copy(
+      uri = in.uri.withHost(proxyHost).withPort(proxyPort).withScheme(proxyScheme).withPath(Uri.Path(proxyPath.toString() + in.uri.path.toString())),
       headers = in.headers.map {
         case Host(_, _) => Host(proxyHost)
         case header => header
       }
     )
+    val hostConnectorSetup = HostConnectorSetup(proxyHost, proxyPort, sslEncryption = true)
+    (io ?(request, hostConnectorSetup)).mapTo[HttpResponse].map(
+      logProxyResp(metrics) ~>
+        filterHeaders ~>
+        changeResponseCode
+    )
+  }
 
   def logProxyResp(metrics: CASMetrics): HttpResponse => HttpResponse = { resp =>
+    metrics.putRequest
     metrics.putResponseCode(resp.status.intValue, "POST")
     resp
   }
@@ -56,27 +68,47 @@ trait ProxyDirective extends Directives with ErrorRoute {
       case _ => true
     })
 
-  def hostConnectorSetup = HostConnectorSetup(proxyHost, proxyPort, sslEncryption = true)
+  private def compareSubscriptionRequests(request: HttpRequest, casResponse: Future[HttpResponse]): Unit = {
+    val uri: Uri = request.uri
+    val isSubsRequest = uri.path != null &&
+      uri.path.toString().contains("/subs")
 
-  def sendReceive(request: HttpRequest, metrics: CASMetrics, followRedirect: Boolean = true): Future[HttpResponse] = {
-    (io ? (request, hostConnectorSetup)).mapTo[HttpResponse].map(
-      logProxyResp(metrics) ~>
-          filterHeaders ~>
-          changeResponseCode
-    )
+    def compareResponses(oldResponse: HttpResponse, newResponse: HttpResponse) {
+      val hasSameStatus = oldResponse.status == newResponse.status
+      val hasSameBody = oldResponse.entity.asString == newResponse.entity.asString
+      if (!hasSameStatus && !hasSameBody)
+        logger.error("Legacy apps returned different Responses")
+      else
+        logger.info("Legacy apps returned same Responses ")
+    }
+
+    if (isSubsRequest) {
+      logger.info("Subs request made, comparing old with new CAS instances")
+      for {
+        oldResponse <- casResponse
+        newResponse <- proxyRequest(request, Configuration.proxyNew)
+      } yield compareResponses(oldResponse, newResponse)
+    }
   }
 
   lazy val casRoute: Route = {
-    val metrics = new CASMetrics(Configuration.stage)
-    ctx => ctx.complete(sendReceive(proxyRequest(ctx.request), metrics))
+    ctx => {
+      val request: HttpRequest = ctx.request
+      val casResponse = proxyRequest(request, Configuration.proxy)
+      ctx.complete(casResponse)
+      try {
+        compareSubscriptionRequests(request, casResponse)
+      }
+      catch {
+        case e: Exception => logger.error("Error comparing SubscriptionRequests", e)
+      }
+    }
   }
 
   val authRoute: Route = (path("auth") & post)(casRoute)
 
   def zuoraRoute(subsReq: SubscriptionRequest): Route = zuoraDirective(subsReq) { subscriptionName =>
-
     val validSubscription = subscriptionService.getValidSubscription(subscriptionName, subsReq.password)
-
     onSuccess(validSubscription) {
       case Some(subscription) =>
         subscriptionService.updateActivationDate(subscription)

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -83,7 +83,6 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
     }
 
     if (isSubsRequest) {
-      logger.info("Subs request made, comparing old with new CAS instances")
       for {
         oldResponse <- casResponse
         newResponse <- proxyRequest(request, Configuration.proxyNew)

--- a/src/main/scala/com/gu/subscriptions/cas/model/ResponseComparer.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/model/ResponseComparer.scala
@@ -5,13 +5,20 @@ import spray.http.HttpResponse
 
 object ResponseComparer extends LazyLogging {
   def compare(response: HttpResponse, other: HttpResponse): Unit = {
+    val sanitize = (in:String) => in.replaceAll(" ", "").replaceAll("\n", "")
+    val responseBody: String = response.entity.asString
+    val otherResponseBody: String = other.entity.asString
+
     def isSame = {
       val hasSameStatus = response.status == other.status
-      val hasSameBody = response.entity.asString == other.entity.asString
+      val hasSameBody = sanitize(responseBody) == sanitize(otherResponseBody)
       hasSameBody && hasSameStatus
     }
-    if (!isSame)
+    if (!isSame) {
       logger.error("Legacy apps returned different Responses")
+      logger.error(responseBody)
+      logger.error(otherResponseBody)
+    }
     else
       logger.info("Legacy apps returned same Responses ")
   }

--- a/src/main/scala/com/gu/subscriptions/cas/model/ResponseComparer.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/model/ResponseComparer.scala
@@ -1,0 +1,18 @@
+package com.gu.subscriptions.cas.model
+
+import com.typesafe.scalalogging.LazyLogging
+import spray.http.HttpResponse
+
+object ResponseComparer extends LazyLogging {
+  def compare(response: HttpResponse, other: HttpResponse): Unit = {
+    def isSame = {
+      val hasSameStatus = response.status == other.status
+      val hasSameBody = response.entity.asString == other.entity.asString
+      hasSameBody && hasSameStatus
+    }
+    if (!isSame)
+      logger.error("Legacy apps returned different Responses")
+    else
+      logger.info("Legacy apps returned same Responses ")
+  }
+}


### PR DESCRIPTION
In the interim while we have a new and old version of CAS running then we need to ensure that the requests to both systems that don't have side effects (i.e. /subs requests) return the same responses. This change will temporarily send requests to both versions of CAS and compare the responses. 