### PR TITLE
New CAS instance now has correct domain name an certificate + update AMI

### DIFF
--- a/cloudformation/content-authorisation-proxy.cf.json
+++ b/cloudformation/content-authorisation-proxy.cf.json
@@ -62,7 +62,7 @@
         "CASProxyLaunchConfig" : {
             "Type" : "AWS::AutoScaling::LaunchConfiguration",
             "Properties" : {
-                "ImageId" : "ami-177c4d60",
+                "ImageId" : "ami-6857e51b",
                 "SecurityGroups" : [ { "Ref" : "InstanceSecurityGroup" } ],
                 "InstanceType" : "t2.small",
                 "KeyName" : { "Ref" : "KeyName" },

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
-//proxy = "https://cas-legacy.subscriptions.guardianapis.com/"
-proxy = "http://subs-cas-CASLegac-ZWI0H7Z9JY8T-1440512801.eu-west-1.elb.amazonaws.com/"
+proxy = "https://cas-legacy.subscriptions.guardianapis.com/"
+//proxy = "http://subs-cas-CASLegac-ZWI0H7Z9JY8T-1440512801.eu-west-1.elb.amazonaws.com/"
 
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,4 @@
 proxy = "https://cas-legacy.subscriptions.guardianapis.com/"
-//proxy = "http://subs-cas-CASLegac-ZWI0H7Z9JY8T-1440512801.eu-west-1.elb.amazonaws.com/"
 
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]


### PR DESCRIPTION
The new instance of CAS now has the correct ccas-legacy.subscriptions.guardianapis.com domain name and the *.subscriptions.guardianapis SSL certificate added to it. Therefore we can now point CAS proxy to this address using https

Updating AMI to fix critical security vulnerability: https://googleonlinesecurity.blogspot.co.uk/2016/02/cve-2015-7547-glibc-getaddrinfo-stack.html

/cc @tomverran 