### PR TITLE
Do not fill in the ActivationDate when there is a noActivation query …

### DIFF
--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -84,11 +84,11 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
 
   val authRoute: Route = (path("auth") & post)(casRoute)
 
-  def zuoraRoute(subsReq: SubscriptionRequest): Route = zuoraDirective(subsReq) { subscriptionName =>
+  def zuoraRoute(subsReq: SubscriptionRequest): Route = zuoraDirective(subsReq) { (activation, subscriptionName) =>
     val validSubscription = subscriptionService.getValidSubscription(subscriptionName, subsReq.password)
     onSuccess(validSubscription) {
       case Some(subscription) =>
-        subscriptionService.updateActivationDate(subscription)
+        if (activation) { subscriptionService.updateActivationDate(subscription) }
         complete(SubscriptionExpiration(subscription.termEndDate))
       case _ =>
         notFound

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ZuoraDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ZuoraDirective.scala
@@ -1,18 +1,24 @@
 package com.gu.subscriptions.cas.directives
 
+import com.gu.subscriptions.cas.directives.ZuoraDirective.{SubscriptionNumber, TriggersActivation}
 import com.gu.subscriptions.cas.model.SubscriptionRequest
-import shapeless.{HNil, ::}
-import spray.routing.{Route, Directive1}
-import spray.routing.directives.RouteDirectives.reject
+import shapeless.{::, HNil}
+import spray.routing.{Directive, Route}
+import spray.routing.Directives._
 
 object ZuoraDirective {
-  def zuoraDirective(subscriptionRequest: SubscriptionRequest): Directive1[String] = new ZuoraDirective(subscriptionRequest)
+  type TriggersActivation = Boolean
+  type SubscriptionNumber = String
+  def zuoraDirective(subscriptionRequest: SubscriptionRequest): Directive[TriggersActivation :: SubscriptionNumber :: HNil] = new ZuoraDirective(subscriptionRequest)
 }
 
-class ZuoraDirective(subscriptionRequest: SubscriptionRequest) extends Directive1[String] {
-  override def happly(f: (String :: HNil) => Route): Route = {
+class ZuoraDirective(subscriptionRequest: SubscriptionRequest) extends Directive[TriggersActivation :: SubscriptionNumber :: HNil] {
+  override def happly(f: (TriggersActivation :: SubscriptionNumber :: HNil) => Route): Route = {
     subscriptionRequest.subscriberId.filter(_.startsWith("A-S")) match {
-      case Some(subId) => f(subId :: HNil)
+      case Some(subId) =>
+        parameter("noActivation") { _ =>
+          f(false :: subId :: HNil)
+        } ~ f(true :: subId :: HNil)
       case _ => reject
     }
   }

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ZuoraDirectiveTest.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ZuoraDirectiveTest.scala
@@ -3,6 +3,7 @@ package com.gu.subscriptions.cas.directives
 
 import com.gu.subscriptions.cas.model.SubscriptionRequest
 import org.scalatest.{FlatSpec, Matchers}
+import spray.http.Uri
 import spray.routing.{HttpService, Route}
 import spray.testkit.ScalatestRouteTest
 
@@ -15,7 +16,7 @@ class ZuoraDirectiveTest extends FlatSpec with Matchers with ScalatestRouteTest 
 
   "A SubscriptionRequest" should "pass if subscriberId starts with A-S" in {
     val subscriptionRequest = new SubscriptionRequest(Some("A-S00056789"), "password")
-    val route: Route = ZuoraDirective.zuoraDirective(subscriptionRequest) { subId =>
+    val route: Route = ZuoraDirective.zuoraDirective(subscriptionRequest) { (triggersActivation, subId) =>
       complete(subId)
     }
     Get("/") ~> route ~> check {
@@ -25,11 +26,27 @@ class ZuoraDirectiveTest extends FlatSpec with Matchers with ScalatestRouteTest 
 
   "A SubscriptionRequest" should "be rejected if the subscriberId does not start with A-S" in {
     val subscriptionRequest = new SubscriptionRequest(Some("100056789"), "password")
-    val route: Route = ZuoraDirective.zuoraDirective(subscriptionRequest) { subId =>
+    val route: Route = ZuoraDirective.zuoraDirective(subscriptionRequest) { (triggersActivation, subId) =>
       complete(subId)
     }
     Get("/") ~> route ~> check {
       assert(!handled)
+    }
+  }
+
+  "A SubscriptionRequest" should "return a true triggersActivation value unless given a noActivation query parameter" in {
+    val subscriptionRequest = new SubscriptionRequest(Some("A-S00056789"), "password")
+    val route: Route = ZuoraDirective.zuoraDirective(subscriptionRequest) { (triggersActivation, subId) =>
+      val activation = if (triggersActivation) "true" else "false"
+      complete(activation)
+    }
+
+    Get("/") ~> route ~> check {
+      responseAs[String] should be("true")
+    }
+
+    Get(Uri("/").withQuery(("noActivation", "true"))) ~> route ~> check {
+      responseAs[String] should be("false")
     }
   }
 


### PR DESCRIPTION
This is to prevent the future admin tool from updating the activation date by just querying