### PR TITLE
Zuora wsdl 70

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # content-authorisation-proxy
-This proxy's requests to the content authorisation services (CAS) to allow a new content subscription provider to be added
+This proxies requests to the content authorisation services (CAS) to allow a new content subscription provider to be added
 
 * **TeamCity:** https://teamcity.gutools.co.uk/viewType.html?buildTypeId=Subscriptions_ContentAuthorisationProxy
 * **RiffRaff:** https://riffraff.gutools.co.uk/deployment/history?projectName=content-authorisation-proxy

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.39",
-    "com.gu" %% "membership-common" % "0.138",
+    "com.gu" %% "membership-common" % "0.176",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/src/main/scala/com/gu/subscriptions/cas/bootstrap/Bootstrap.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/bootstrap/Bootstrap.scala
@@ -4,9 +4,12 @@ import akka.actor.Props
 import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
-import com.gu.memsub.services.{CatalogService, SubscriptionService => CommonSubscriptionService}
+import com.gu.config.{DiscountRatePlan, DiscountRatePlanIds}
+import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId}
+import com.gu.memsub.services.{SubscriptionService => CommonSubscriptionService, PromoService, CatalogService}
 import com.gu.monitoring.ServiceMetrics
 import com.gu.stripe.{StripeApiConfig, StripeService}
+import com.gu.subscriptions.Discounter
 import com.gu.subscriptions.cas.config.Configuration.{system, _}
 import com.gu.subscriptions.cas.config.Zuora.{Rest, Soap}
 import com.gu.subscriptions.cas.service.SubscriptionService

--- a/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
@@ -28,5 +28,5 @@ object Configuration {
 
   val digipackPlans = DigitalPackRatePlanIds.fromConfig(touchpointConfig.getConfig("zuora.ratePlanIds.digitalpack"))
   val membershipPlans = MembershipRatePlanIds.fromConfig(touchpointConfig.getConfig("zuora.ratePlanIds.membership"))
-  implicit val productFamily = Digipack()
+  implicit val productFamily = Digipack
 }

--- a/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
@@ -12,7 +12,7 @@ object Zuora {
     val metrics = new ServiceMetrics(appStage, appName, "zuora-soap-client")
     val client = new ClientWithFeatureSupplier(featureCodes = Set.empty,
                                                apiConfig = apiConfig,
-                                               metrics = metrics,
+                                               metrics = metrics)(
                                                actorSystem = Configuration.system)
   }
 

--- a/src/main/scala/com/gu/subscriptions/cas/service/SubscriptionService.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/service/SubscriptionService.scala
@@ -1,7 +1,7 @@
 package com.gu.subscriptions.cas.service
 
 import com.github.nscala_time.time.Imports._
-import com.gu.memsub.Subscription
+import com.gu.memsub.{Digipack, Subscription}
 import com.gu.memsub.Subscription.Name
 import com.gu.memsub.services.CatalogService
 import com.gu.memsub.services.api.{SubscriptionService => CommonSubscriptionService}

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
@@ -3,7 +3,7 @@ package com.gu.subscriptions.cas.directives
 import akka.testkit.TestProbe
 import com.gu.i18n.GBP
 import com.gu.memsub.Subscription
-import com.gu.memsub.Subscription.{FeatureId, ProductRatePlanId, Name}
+import com.gu.memsub.Subscription.{ProductRatePlanId, Name}
 import com.gu.subscriptions.cas.model.json.ModelJsonProtocol._
 import com.gu.subscriptions.cas.model.{SubscriptionExpiration, SubscriptionRequest}
 import com.gu.subscriptions.cas.service.api.SubscriptionService
@@ -50,13 +50,15 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
       currency = GBP,
       productRatePlanId = ProductRatePlanId("123"),
       productName = "DigitalPack",
-      startDate = new DateTime().toLocalDate,
+      startDate = now.toLocalDate,
+      termStartDate = now.toLocalDate,
       termEndDate = new DateTime().plusYears(1).toLocalDate,
-      features = Set(),
+      features = List.empty[Subscription.Feature],
       casActivationDate = None,
       isCancelled = false,
       ratePlanId = "1234",
-      isPaid = true
+      isPaid = true,
+      promoCode = None
   )
 
 


### PR DESCRIPTION
CAS proxy doesn't do much with Zuora but we should update it to use the same WSDL as everything else