### PR TITLE
Drop leading zeros when querying subs in Zuora

### DIFF
--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -5,6 +5,7 @@ import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
 import com.amazonaws.regions.{Region, Regions}
+import com.gu.memsub.Subscription.Name
 import com.gu.subscriptions.cas.config.Configuration
 import com.gu.subscriptions.cas.config.HostnameVerifyingClientSSLEngineProvider.provider
 import com.gu.subscriptions.cas.directives.ResponseCodeTransformer._
@@ -97,7 +98,7 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
   val authRoute: Route = (path("auth") & post)(casRoute)
 
   def zuoraRoute(subsReq: SubscriptionRequest): Route = zuoraDirective(subsReq) { (activation, subscriptionName) =>
-    val validSubscription = subscriptionService.getValidSubscription(subscriptionName, subsReq.password)
+    val validSubscription = subscriptionService.getValidSubscription(Name(subscriptionName.get.dropWhile(_ == '0')), subsReq.password)
 
     validSubscription.onFailure {
       case t: Throwable =>

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.FreeSpec
 import spray.http.HttpHeaders._
 import spray.http.MediaTypes.`application/json`
 import spray.http.StatusCodes.BadRequest
-import spray.http._
+import spray.http.{HttpEntity, _}
 import spray.json._
 import spray.routing.{HttpService, Route}
 import spray.testkit.ScalatestRouteTest
@@ -119,6 +119,15 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
         }
       }
       "without a Zuora format" - {
+
+        "Drops leading zeroes before querying Zuora" in {
+          val payload = SubscriptionRequest(Some("00" + subsName), "password").toJson.toString()
+          val req = HttpEntity(`application/json`, payload)
+          Post("/subs", req) ~> inJson(subsRoute) ~> check {
+            assertResult(expiration.toJson)(responseAs[String].parseJson)
+          }
+        }
+
         "proxies the request to CAS" in {
           val payload = SubscriptionRequest(Some("id"), "password").toJson.toString()
           val req = HttpEntity(`application/json`, payload)


### PR DESCRIPTION
The Zuora versions of QSS subs for some reason no longer have leading zeros...