### PR TITLE
Spike: why are a lot of requests getting cascaded?

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= {
     "ch.qos.logback" % "logback-classic" % "1.1.2",
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
-    "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.9.39",
+    "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.50",
     "com.gu" %% "membership-common" % "0.218",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -12,7 +12,7 @@ import com.gu.subscriptions.cas.directives.ResponseCodeTransformer._
 import com.gu.subscriptions.cas.directives.ZuoraDirective._
 import com.gu.subscriptions.cas.model.json.ModelJsonProtocol._
 import com.gu.subscriptions.cas.model.{SubscriptionExpiration, SubscriptionRequest}
-import com.gu.subscriptions.cas.monitoring.{RequestMetrics, StatusMetrics}
+import com.gu.subscriptions.cas.monitoring.{Histogram, RequestMetrics, StatusMetrics}
 import com.gu.subscriptions.cas.service.api.SubscriptionService
 import com.typesafe.scalalogging.LazyLogging
 import spray.can.Http
@@ -97,6 +97,9 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
 
   val authRoute: Route = (path("auth") & post)(casRoute)
 
+  val subsRouteHistogram = new Histogram("subsRoute", 1, DAYS)
+  val zuoraRouteHistogram = new Histogram("zuoraRouteFound", 1, DAYS)
+
   def zuoraRoute(subsReq: SubscriptionRequest): Route = zuoraDirective(subsReq) { (activation, subscriptionName) =>
     val validSubscription = subscriptionService.getValidSubscription(Name(subscriptionName.get.dropWhile(_ == '0')), subsReq.password)
 
@@ -109,6 +112,7 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
     onSuccess(validSubscription) {
       case Some(subscription) =>
         if (activation) { subscriptionService.updateActivationDate(subscription) }
+        subsReq.subscriberId.foreach(zuoraRouteHistogram.count) // requested ID, not Subscription.Name
         //Since the dates are in PST, we want to make sure that we don't cut any subscription one day short
         complete(SubscriptionExpiration(subscription.termEndDate.plusDays(1).toDateTimeAtStartOfDay()))
       case _ if subscriptionName.get.startsWith("A-S") => notFound //no point going to CAS if this is a Zuora sub
@@ -118,6 +122,7 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
 
   val subsRoute = (path("subs") & post) {
     entity(as[SubscriptionRequest]) { subsReq =>
+      subsReq.subscriberId.foreach(subsRouteHistogram.count)
       zuoraRoute(subsReq) ~ casRoute
     } ~ badRequest
   }

--- a/src/main/scala/com/gu/subscriptions/cas/monitoring/Histogram.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/monitoring/Histogram.scala
@@ -29,7 +29,7 @@ class Histogram(name: String = UUID.randomUUID().toString, expire: Int = 1, dura
 
   val actorSystem = ActorSystem(s"histogram-logger-$name")
 
-  actorSystem.scheduler.schedule(0.seconds, 10.seconds) {
+  actorSystem.scheduler.schedule(0.seconds, 1.hour) {
     logger.info(s"""Report:
 Top-50 requested IDs for $name at: ${LocalDateTime.now()}
 - ${getTop(50).map(e => s"${e._1}: ${e._2}").mkString("\n- ")}

--- a/src/main/scala/com/gu/subscriptions/cas/monitoring/Histogram.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/monitoring/Histogram.scala
@@ -1,0 +1,48 @@
+package com.gu.subscriptions.cas.monitoring
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+import com.google.common.cache.CacheBuilder
+import java.util.concurrent.atomic.LongAdder
+
+import akka.actor.ActorSystem
+import com.typesafe.scalalogging.LazyLogging
+
+import collection.JavaConversions._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.Random
+
+/**
+  * This class representes a histogram or frequency-map of strings. It is up to the callee to call count with a string.
+  * The getTop method can be called to see the existing values in the cache. There is thus a reporting maximimum of Integer.MAX.
+  * The class will log to the attached logger, a count of the top 50 requested strings every hour. Hence it requires an implicit ActorSystem.
+  * @param name the name of this histogram, default: a UUID
+  * @param expire the duration to expire the histogram entries. Default: 1
+  * @param duration the time unit to expire the histogram entries. Default: HOURS
+  * @param ec an implicit ExecutionContext required for the scheduled logger
+  */
+class Histogram(name: String = UUID.randomUUID().toString, expire: Int = 1, duration: TimeUnit = HOURS)(implicit ec: ExecutionContext) extends LazyLogging {
+
+  private val countCache = CacheBuilder.newBuilder.expireAfterWrite(expire, duration).build[String, LongAdder]
+
+  val actorSystem = ActorSystem(s"histogram-logger-$name")
+
+  actorSystem.scheduler.schedule(0.seconds, 10.seconds) {
+    logger.info(s"""Report:
+Top-50 requested IDs for $name at: ${LocalDateTime.now()}
+- ${getTop(50).map(e => s"${e._1}: ${e._2}").mkString("\n- ")}
+End of Top-50 report for $name""")
+  }
+
+  def count(key: String) =
+    Option(countCache.getIfPresent(key)).fold {
+      val counter = new LongAdder
+      counter.increment()
+      countCache.put(key, counter)
+    } { _.increment() }
+
+  def getTop(amount: Int) = countCache.asMap().toSeq.filter(_._2.longValue() > 1).sortBy(_._2.longValue()).reverse.take(amount)
+
+}


### PR DESCRIPTION
Adding a histogram cache of the requested set of subscription IDs which logs to CloudWatch every hour.
This is to see why a majority of traffic gets cascaded through to CAS when, given that we've migrated all digipack subs, I wouldn't expect to happen.
I suspect it might be requests for an empty Subscription ID.

https://trello.com/c/Tt0p2veS/571-spike-cas-legacy-not-seeing-drop-in-traffic-since-digipack-migration

cc @tomverran 