### PR TITLE
Added changes needed for paper plus-package subs to get digipacks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization  := "com.gu"
 
 version       := "0.1"
 
-scalaVersion  := "2.11.6"
+scalaVersion  := "2.11.7"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
@@ -33,7 +33,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.50",
-    "com.gu" %% "membership-common" % "0.218",
+    "com.gu" %% "membership-common" % "0.242",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -5,6 +5,20 @@ akka {
   loglevel = "INFO"
 }
 
-knownProducts = ["Digital Pack"]
+stage = "DEV"
+
+# Legacy CAS response error codes, carried over for compatibility
+general.error.code = -1
+unhandled.exception.error.code = -20
+network.error.code = -30
+malformed.request.error.code = -40
+mandatory.data.missing.error.code = -50
+no.free.period.for.device.error.code = -60
+credentials.overuse.error.code = -70
+invalid.subscription.type.error.code = -80
+unknown.subscriber.error.code = -90
+subscription.disabled.error.code = -100
+auth.freeperiod.alreadyset = -110
+auth.freeperiod.tofarinthefuture = -120
 
 include file("/etc/gu/cas-proxy.conf")

--- a/src/main/scala/com/gu/subscriptions/cas/bootstrap/Bootstrap.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/bootstrap/Bootstrap.scala
@@ -4,12 +4,9 @@ import akka.actor.Props
 import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
-import com.gu.config.{DiscountRatePlan, DiscountRatePlanIds}
-import com.gu.memsub.Subscription.{ProductRatePlanChargeId, ProductRatePlanId}
-import com.gu.memsub.services.{SubscriptionService => CommonSubscriptionService, PromoService, CatalogService}
+import com.gu.memsub.services.{CatalogService, SubscriptionService => CommonSubscriptionService}
 import com.gu.monitoring.ServiceMetrics
 import com.gu.stripe.{StripeApiConfig, StripeService}
-import com.gu.subscriptions.Discounter
 import com.gu.subscriptions.cas.config.Configuration.{system, _}
 import com.gu.subscriptions.cas.config.Zuora.{Rest, Soap}
 import com.gu.subscriptions.cas.service.SubscriptionService
@@ -31,10 +28,10 @@ object Bootstrap extends App {
     new StripeService(stripeApiConfig, stripeMetrics)
   }
 
-  val zuoraService = new ZuoraService(Soap.client, Rest.client, digipackPlans)
-  val catalogService = CatalogService(Rest.client, membershipPlans, digipackPlans, stage)
+  val zuoraService = new ZuoraService(Soap.client, Rest.client)
+  val catalogService = CatalogService(Rest.client, subsIds, membershipPlans, digipackPlans, stage)
 
-  val commonSubscriptionService = new CommonSubscriptionService(zuoraService, stripeService, catalogService.digipackCatalog)
+  val commonSubscriptionService = new CommonSubscriptionService(zuoraService, stripeService, catalogService.paperCatalog)
   val subscriptionService = new SubscriptionService(zuoraService, commonSubscriptionService, catalogService)
   val service = system.actorOf(Props(classOf[CASService], subscriptionService))
 

--- a/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
@@ -1,7 +1,7 @@
 package com.gu.subscriptions.cas.config
 
 import akka.actor.ActorSystem
-import com.gu.config.{MembershipRatePlanIds, DigitalPackRatePlanIds}
+import com.gu.config.{DigitalPackRatePlanIds, MembershipRatePlanIds, SubscriptionsProductIds}
 import com.gu.memsub.Digipack
 import com.typesafe.config.ConfigFactory
 
@@ -28,5 +28,20 @@ object Configuration {
 
   val digipackPlans = DigitalPackRatePlanIds.fromConfig(touchpointConfig.getConfig("zuora.ratePlanIds.digitalpack"))
   val membershipPlans = MembershipRatePlanIds.fromConfig(touchpointConfig.getConfig("zuora.ratePlanIds.membership"))
+  val subsIds = SubscriptionsProductIds(touchpointConfig.getConfig("zuora.productIds.subscriptions"))
+
+  val generalErrorCode = appConfig.getInt("general.error.code")
+  val unhandledExceptionErrorCode = appConfig.getInt("unhandled.exception.error.code")
+  val networkErrorCode = appConfig.getInt("network.error.code")
+  val malformedRequestErrorCode = appConfig.getInt("malformed.request.error.code")
+  val mandatoryDataMissingErrorCode = appConfig.getInt("mandatory.data.missing.error.code")
+  val noFreePeriodForDeviceErrorCode = appConfig.getInt("no.free.period.for.device.error.code")
+  val credentialsOverUseErrorCode = appConfig.getInt("credentials.overuse.error.code")
+  val invalidSubscriptionTypeErrorCode = appConfig.getInt("invalid.subscription.type.error.code")
+  val unknownSubscriberErrorCode = appConfig.getInt("unknown.subscriber.error.code")
+  val subscriptionDisabledErrorCode = appConfig.getInt("subscription.disabled.error.code")
+  val authFreeperiodAlreadyset = appConfig.getInt("auth.freeperiod.alreadyset")
+  val authFreeperiodTofarinthefuture = appConfig.getInt("auth.freeperiod.tofarinthefuture")
+
   implicit val productFamily = Digipack
 }

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ErrorRoute.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ErrorRoute.scala
@@ -1,19 +1,20 @@
 package com.gu.subscriptions.cas.directives
 
+import com.gu.subscriptions.cas.config.Configuration.{system, _}
 import spray.http.{HttpResponse, StatusCodes}
-import spray.json.{JsString, JsObject}
+import spray.json.{JsObject, JsString, JsNumber}
 import spray.routing.Route
 import spray.routing.directives.RouteDirectives.complete
 
 trait ErrorRoute {
-  def errorMsg(msg: String): String =
-    JsObject("error" -> JsObject("message" -> JsString(msg))).toString()
+  def errorMsg(msg: String, code: Int): String =
+    JsObject("error" -> JsObject("message" -> JsString(msg), "code" -> JsNumber(code))).toString()
 
   val badRequest: Route =
     complete(
       HttpResponse(
         status = StatusCodes.BadRequest,
-        entity = errorMsg("Bad request")
+        entity = errorMsg("Mandatory data missing from request", mandatoryDataMissingErrorCode)
       )
     )
 
@@ -21,7 +22,7 @@ trait ErrorRoute {
     complete(
       HttpResponse(
         status = StatusCodes.NotFound,
-        entity = errorMsg("Not found")
+        entity = errorMsg("Unknown subscriber", unknownSubscriberErrorCode)
       )
     )
 
@@ -29,7 +30,7 @@ trait ErrorRoute {
     complete(
       HttpResponse(
         status = StatusCodes.InternalServerError,
-        entity = errorMsg("Internal server error")
+        entity = errorMsg("Internal server error", generalErrorCode)
       )
     )
 
@@ -37,7 +38,7 @@ trait ErrorRoute {
     complete(
       HttpResponse(
         status = StatusCodes.ServiceUnavailable,
-        entity = errorMsg("Service Unavailable. Please try again later")
+        entity = errorMsg("Service Unavailable. Please try again later", networkErrorCode)
       )
     )
 }

--- a/src/main/scala/com/gu/subscriptions/cas/directives/HealthCheckDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/HealthCheckDirective.scala
@@ -8,6 +8,9 @@ import spray.routing.{HttpService, Route}
 
 trait HealthCheckDirective extends LazyLogging with ErrorRoute {this: HttpService =>
   def subscriptionService: SubscriptionService
+
+  val completeResponse = s"""{ "status": "ok" , "gitCommitId": "${app.BuildInfo.gitCommitId}" }"""
+
   val healthCheck: Route =
     (get & path("healthcheck") & respondWithMediaType(`application/json`)) {
       // Make sure that the inner route gets reevaluated each time, as the Zuora service availability changes
@@ -21,7 +24,7 @@ trait HealthCheckDirective extends LazyLogging with ErrorRoute {this: HttpServic
             logger.warn("Service not ready yet")
             serviceUnavailableError
           } else {
-            complete(s"""{ "status": "ok" , "gitCommitId": "${app.BuildInfo.gitCommitId}" }""")
+            complete(completeResponse)
           }
 
         }

--- a/src/main/scala/com/gu/subscriptions/cas/model/SubscriptionExpiration.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/model/SubscriptionExpiration.scala
@@ -1,4 +1,12 @@
 package com.gu.subscriptions.cas.model
 import org.joda.time.DateTime
 
-case class SubscriptionExpiration(expiryDate: DateTime, expiryType: String = "sub", content: String = "SevenDay")
+case class SubscriptionExpiration(expiryDate: DateTime, expiryType: String, content: String = "SevenDay")
+
+object ExpiryType {
+  val SUB = "sub"
+  val FREE = "free"
+  val SPECIAL = "special" // deprecated
+  val DEFAULT = "default"
+  val DEVICE_CONFIGURED= "deviceConfigured"
+}

--- a/src/main/scala/com/gu/subscriptions/cas/model/SubscriptionRequest.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/model/SubscriptionRequest.scala
@@ -1,3 +1,3 @@
 package com.gu.subscriptions.cas.model
 
-case class SubscriptionRequest(subscriberId: Option[String], password:String)
+case class SubscriptionRequest(subscriberId: Option[String], password: Option[String])

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ZuoraDirectiveTest.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ZuoraDirectiveTest.scala
@@ -20,15 +20,15 @@ class ZuoraDirectiveTest extends FlatSpec with Matchers with ScalatestRouteTest 
   "A SubscriptionRequest" should "pass always" in {
 
     // we always want to check zuora now people are being migrated over
-    val zuoraSubRequest = new SubscriptionRequest(Some("A-S00056789"), "password")
-    val casSubRequest = new SubscriptionRequest(Some("00123455"), "password")
+    val zuoraSubRequest = new SubscriptionRequest(Some("A-S00056789"), Some("password"))
+    val casSubRequest = new SubscriptionRequest(Some("00123455"), Some("password"))
     Get("/") ~> routeFor(zuoraSubRequest) ~> check { responseAs[String] should be("A-S00056789") }
     Get("/") ~> routeFor(casSubRequest) ~> check { responseAs[String] should be("00123455") }
   }
 
 
   "A SubscriptionRequest" should "return a true triggersActivation value unless given a noActivation query parameter" in {
-    val subscriptionRequest = new SubscriptionRequest(Some("A-S00056789"), "password")
+    val subscriptionRequest = new SubscriptionRequest(Some("A-S00056789"), Some("password"))
     val route: Route = ZuoraDirective.zuoraDirective(subscriptionRequest) { (triggersActivation, subId) =>
       val activation = if (triggersActivation) "true" else "false"
       complete(activation)

--- a/src/test/scala/com/gu/subscriptions/cas/model/json/ModelJsonProtocolSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/model/json/ModelJsonProtocolSpec.scala
@@ -1,7 +1,7 @@
 package com.gu.subscriptions.cas.model.json
 
 import com.gu.subscriptions.CAS.CASError
-import com.gu.subscriptions.cas.model.SubscriptionExpiration
+import com.gu.subscriptions.cas.model.{SubscriptionExpiration, ExpiryType}
 import org.joda.time.DateTime
 import org.scalatest.FreeSpec
 import spray.json._
@@ -27,7 +27,8 @@ class ModelJsonProtocolSpec extends FreeSpec {
   "For SubscriptionExpiration" - {
     "handles serialization" in {
       val expiration = SubscriptionExpiration(
-        expiryDate = new DateTime(2015, 5, 21, 12, 0)
+        expiryDate = new DateTime(2015, 5, 21, 12, 0),
+        expiryType = ExpiryType.SUB
       )
 
       val expected =


### PR DESCRIPTION
- Added changes needed for paper plus-package subs to get digipacks
- Most of the changes are collateral from making password optional (ready for the below).
- Added TODO comments which describe the changes for how this app can start handling legacy CAS's auth calls.
- Backported the error codes from legacy CAS and put them in the error response.

cc @tomverran @nlindblad @mario-galic 