### PR TITLE
Histogram for auth

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization  := "com.gu"
 
 version       := "0.1"
 
-scalaVersion  := "2.11.7"
+scalaVersion  := "2.11.8"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ZuoraDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ZuoraDirective.scala
@@ -1,15 +1,19 @@
 package com.gu.subscriptions.cas.directives
 
 import com.gu.memsub.Subscription.Name
-import com.gu.subscriptions.cas.directives.ZuoraDirective.TriggersActivation
+import com.gu.subscriptions.cas.directives.ZuoraDirective.{TriggersActivation, noSubscriberIdPassedToSubs}
 import com.gu.subscriptions.cas.model.SubscriptionRequest
+import com.gu.subscriptions.cas.monitoring.Histogram
 import shapeless.{::, HNil}
 import spray.routing.{Directive, Route}
 import spray.routing.Directives._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 object ZuoraDirective {
   type TriggersActivation = Boolean
   def zuoraDirective(subscriptionRequest: SubscriptionRequest): Directive[TriggersActivation :: Name :: HNil] = new ZuoraDirective(subscriptionRequest)
+  val noSubscriberIdPassedToSubs = new Histogram("noSubscriberIdPassedToSubs", 1, DAYS)
 }
 
 class ZuoraDirective(subscriptionRequest: SubscriptionRequest) extends Directive[TriggersActivation :: Name :: HNil] {
@@ -19,7 +23,9 @@ class ZuoraDirective(subscriptionRequest: SubscriptionRequest) extends Directive
         parameter("noActivation") { _ =>
           f(false :: Name(subId) :: HNil)
         } ~ f(true :: Name(subId) :: HNil)
-      case _ => reject
+      case _ =>
+        noSubscriberIdPassedToSubs.count("NoSubscriberIdPassedToSubs") // clients should not be doing this
+        reject
     }
   }
 }

--- a/src/main/scala/com/gu/subscriptions/cas/model/SubscriptionRequest.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/model/SubscriptionRequest.scala
@@ -1,3 +1,3 @@
 package com.gu.subscriptions.cas.model
 
-case class SubscriptionRequest(subscriberId: Option[String], password: Option[String])
+case class SubscriptionRequest(subscriberId: Option[String], password: Option[String], authType: Option[String])

--- a/src/main/scala/com/gu/subscriptions/cas/model/json/ModelJsonProtocol.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/model/json/ModelJsonProtocol.scala
@@ -14,7 +14,7 @@ object ModelJsonProtocol extends DefaultJsonProtocol {
     ))
   }
 
-  implicit val subsRequestFormat = jsonFormat2(SubscriptionRequest)
+  implicit val subsRequestFormat = jsonFormat3(SubscriptionRequest)
 
   case class CASErrorWrapper(error: CASError)
 

--- a/src/main/scala/com/gu/subscriptions/cas/monitoring/Histogram.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/monitoring/Histogram.scala
@@ -1,6 +1,5 @@
 package com.gu.subscriptions.cas.monitoring
 
-import java.time.LocalDateTime
 import java.util.UUID
 
 import com.google.common.cache.CacheBuilder
@@ -9,10 +8,9 @@ import java.util.concurrent.atomic.LongAdder
 import akka.actor.ActorSystem
 import com.typesafe.scalalogging.LazyLogging
 
-import collection.JavaConversions._
+import collection.JavaConversions.mapAsScalaMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.Random
 
 /**
   * This class representes a histogram or frequency-map of strings. It is up to the callee to call count with a string.
@@ -39,12 +37,16 @@ End of report for `$name`""")
   }
 
   def count(key: String) =
-    Option(countCache.getIfPresent(key)).fold {
-      val counter = new LongAdder
-      counter.increment()
-      countCache.put(key, counter)
-    } { _.increment() }
+    if (!key.isEmpty) {
+      Option(countCache.getIfPresent(key)).fold {
+        val counter = new LongAdder
+        counter.increment()
+        countCache.put(key, counter)
+      } {
+        _.increment()
+      }
+    }
 
-  def getTop(amount: Int) = countCache.asMap().toStream.filter(_._2.longValue() > 3).sortBy(_._2.longValue()).reverse.take(amount)
+  def getTop(amount: Int) = countCache.asMap().filter(_._2.longValue() > 3).toSeq.sortBy(_._2.longValue()).reverse.take(amount)
 
 }

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
@@ -96,7 +96,7 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
     "when a valid request is made" - {
       "with a Zuora-formatted subscriber id" - {
         "returns the expiration with one day leeway" in {
-          val payload = SubscriptionRequest(Some(subsName), Some("password")).toJson.toString()
+          val payload = SubscriptionRequest(Some(subsName), Some("password"), None).toJson.toString()
           val req = HttpEntity(`application/json`, payload)
 
           Post("/subs", req) ~> inJson(subsRoute) ~> check {
@@ -108,7 +108,7 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
       "when an Invalid request is made" - {
         "with a Zuora-formatted subscriber id" - {
           "Returns a 404" in {
-            val payload = SubscriptionRequest(Some("A-S-invalid"), Some("password")).toJson.toString()
+            val payload = SubscriptionRequest(Some("A-S-invalid"), Some("password"), None).toJson.toString()
             val req = HttpEntity(`application/json`, payload)
 
             Post("/subs", req) ~> inJson(subsRoute) ~> check {
@@ -120,7 +120,7 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
       "without a Zuora format" - {
 
         "Drops leading zeroes before querying Zuora" in {
-          val payload = SubscriptionRequest(Some("00" + subsName), Some("password")).toJson.toString()
+          val payload = SubscriptionRequest(Some("00" + subsName), Some("password"), None).toJson.toString()
           val req = HttpEntity(`application/json`, payload)
           Post("/subs", req) ~> inJson(subsRoute) ~> check {
             assertResult(expiration.toJson)(responseAs[String].parseJson)
@@ -128,7 +128,7 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
         }
 
         "proxies the request to CAS" in {
-          val payload = SubscriptionRequest(Some("id"), Some("password")).toJson.toString()
+          val payload = SubscriptionRequest(Some("id"), Some("password"), None).toJson.toString()
           val req = HttpEntity(`application/json`, payload)
 
           Post("/subs", req) ~> inJson(subsRoute) ~> check {

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ZuoraDirectiveTest.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ZuoraDirectiveTest.scala
@@ -20,15 +20,15 @@ class ZuoraDirectiveTest extends FlatSpec with Matchers with ScalatestRouteTest 
   "A SubscriptionRequest" should "pass always" in {
 
     // we always want to check zuora now people are being migrated over
-    val zuoraSubRequest = new SubscriptionRequest(Some("A-S00056789"), Some("password"))
-    val casSubRequest = new SubscriptionRequest(Some("00123455"), Some("password"))
+    val zuoraSubRequest = new SubscriptionRequest(Some("A-S00056789"), Some("password"), None)
+    val casSubRequest = new SubscriptionRequest(Some("00123455"), Some("password"), None)
     Get("/") ~> routeFor(zuoraSubRequest) ~> check { responseAs[String] should be("A-S00056789") }
     Get("/") ~> routeFor(casSubRequest) ~> check { responseAs[String] should be("00123455") }
   }
 
 
   "A SubscriptionRequest" should "return a true triggersActivation value unless given a noActivation query parameter" in {
-    val subscriptionRequest = new SubscriptionRequest(Some("A-S00056789"), Some("password"))
+    val subscriptionRequest = new SubscriptionRequest(Some("A-S00056789"), Some("password"), None)
     val route: Route = ZuoraDirective.zuoraDirective(subscriptionRequest) { (triggersActivation, subId) =>
       val activation = if (triggersActivation) "true" else "false"
       complete(activation)


### PR DESCRIPTION
- Added more logging to see what authType is getting passed in to /auth or /subs - this will help determine whether they are coupled in any way (and need to share the same datastore post migration).
- Added logging to see if any subscriberIds are passed in to /auth - this will highlight any dodgy clients.
- Removed the old logging from /subs.
cc @tomverran 