### PR TITLE
Update to latest membership common

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.50",
-    "com.gu" %% "membership-common" % "0.242",
+    "com.gu" %% "membership-common" % "0.285",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Configuration.scala
@@ -1,7 +1,7 @@
 package com.gu.subscriptions.cas.config
 
 import akka.actor.ActorSystem
-import com.gu.config.{DigitalPackRatePlanIds, MembershipRatePlanIds, SubscriptionsProductIds}
+import com.gu.config.{DigitalPackRatePlanIds, MembershipRatePlanIds, SubsV2ProductIds, SubscriptionsProductIds}
 import com.gu.memsub.Digipack
 import com.typesafe.config.ConfigFactory
 
@@ -44,4 +44,10 @@ object Configuration {
   val authFreeperiodTofarinthefuture = appConfig.getInt("auth.freeperiod.tofarinthefuture")
 
   implicit val productFamily = Digipack
+
+  def productIds(env: String): com.gu.memsub.subsv2.reads.ChargeListReads.ProductIds =
+    SubsV2ProductIds(touchpointConfig.getConfig("zuora.productIds"))
+
+
+
 }

--- a/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
@@ -2,26 +2,31 @@ package com.gu.subscriptions.cas.config
 
 import com.amazonaws.regions.{Region, Regions}
 import com.gu.monitoring.{CloudWatch, ServiceMetrics}
-import com.gu.subscriptions.cas.config.Configuration.{appName, stage => appStage, touchpointConfig}
-import com.gu.zuora.soap.ClientWithFeatureSupplier
-import com.gu.zuora.{ZuoraApiConfig, rest}
+import com.gu.okhttp.RequestRunners._
+import com.gu.subscriptions.cas.config.Configuration.{appName, touchpointConfig, stage => appStage}
+import com.gu.zuora.{ZuoraApiConfig, rest, soap}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scalaz.std.scalaFuture._
 
 object Zuora {
 
   implicit val actorSystem = Configuration.system
+  implicit val ec = actorSystem.dispatcher
 
   object Soap {
     val apiConfig = ZuoraApiConfig.soap(touchpointConfig, appStage)
-    val metrics = new ServiceMetrics(appStage, appName, "zuora-soap-client")
-    val client = new ClientWithFeatureSupplier(featureCodes = Set.empty,
-                                               apiConfig = apiConfig,
-                                               metrics = metrics)
+    val metrics = new ServiceMetrics(Configuration.stage, Configuration.appName, "zuora-soap-client")
+    val client = new soap.ClientWithFeatureSupplier(Set.empty, apiConfig, loggingRunner(metrics), configurableLoggingRunner(20.seconds, metrics))
+    val simpleClient = new rest.SimpleClient[Future](Rest.apiConfig, futureRunner)
   }
 
   object Rest {
     val apiConfig = ZuoraApiConfig.rest(touchpointConfig, appStage)
     val metrics = new ServiceMetrics(appStage, appName, "zuora-rest-client")
-    val client = new rest.Client(apiConfig, metrics)
+    val simpleClient = new rest.SimpleClient[Future](apiConfig, futureRunner)
+    val client = new rest.Client(apiConfig, new ServiceMetrics(appStage, appName, "zuora-rest-client"))
   }
 
   val cloudWatch = new CloudWatch {

--- a/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/directives/ProxyDirective.scala
@@ -5,8 +5,9 @@ import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
 import com.amazonaws.regions.{Region, Regions}
-import com.gu.memsub.Subscription
 import com.gu.memsub.Subscription.Name
+import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.subsv2.SubscriptionPlan.Paid
 import com.gu.subscriptions.cas.config.Configuration
 import com.gu.subscriptions.cas.config.HostnameVerifyingClientSSLEngineProvider.provider
 import com.gu.subscriptions.cas.directives.ResponseCodeTransformer._
@@ -143,7 +144,7 @@ trait ProxyDirective extends Directives with ErrorRoute with LazyLogging {
     }
 
     onSuccess(validSubscription) {
-      case Some(subscription: Subscription) =>
+      case Some(subscription: Subscription[Paid]) =>
         if (activation) { subscriptionService.updateActivationDate(subscription) }
         // TODO ASAP - if deviceId and appId are provided:
           // upsert a record in DynamoDB

--- a/src/main/scala/com/gu/subscriptions/cas/service/SubscriptionService.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/service/SubscriptionService.scala
@@ -1,26 +1,25 @@
 package com.gu.subscriptions.cas.service
 
 import com.github.nscala_time.time.Imports._
+import com.gu.memsub.Digipack
 import com.gu.memsub.Subscription.Name
-import com.gu.memsub.services.CatalogService
-import com.gu.memsub.services.api.{SubscriptionService => CommonSubscriptionService}
-import com.gu.memsub.{Digipack, PaymentStatus, Subscription}
+import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.subsv2.SubscriptionPlan.Paid
+import com.gu.memsub.subsv2.reads.ChargeListReads._
+import com.gu.memsub.subsv2.services.{ SubscriptionService => CommonSubscriptionService }
 import com.gu.subscriptions.cas.config.Zuora._
 import com.gu.subscriptions.cas.model.ContactOps.WithMatchingPassword
-import com.gu.subscriptions.{PaperCatalog, ProductList, ProductPlan}
 import com.gu.zuora.api.ZuoraService
 import com.typesafe.scalalogging.LazyLogging
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class SubscriptionService(zuoraService: ZuoraService,
-                          commonSubscriptionService: CommonSubscriptionService[PaperCatalog],
-                          catalogService: CatalogService) extends api.SubscriptionService with LazyLogging  {
-  def getValidSubscription(subscriptionName: Name, password: String): Future[Option[Subscription]] = {
-    def checkSubscriptionValidity(subscription: Subscription with PaymentStatus[ProductPlan[ProductList]]): Future[Boolean] = {
+                          commonSubscriptionService: CommonSubscriptionService[Future]) extends api.SubscriptionService with LazyLogging {
+  def getValidSubscription(subscriptionName: Name, password: String): Future[Option[Subscription[Paid]]] = {
+    def checkSubscriptionValidity(subscription: Subscription[Paid]): Future[Boolean] = {
       val postcodeCheck =
-        if(subscription.plan.products.seq.contains(Digipack)) {
+        if (subscription.plan.charges.benefits.list.contains(Digipack)) {
           for {
             account <- zuoraService.getAccount(subscription.accountId)
             contact <- zuoraService.getContact(account.billToId)
@@ -41,14 +40,20 @@ class SubscriptionService(zuoraService: ZuoraService,
     }
 
     for {
-      subscription <- commonSubscriptionService.get(subscriptionName)
+      subscription <- commonSubscriptionService.get[Paid](subscriptionName)
       isValid <- subscription.fold(Future.successful(false))(checkSubscriptionValidity)
     } yield subscription.filter(_ => isValid)
   }
 
   def isReady: Boolean = zuoraService.lastPingTimeWithin(2.minutes)
 
-  def updateActivationDate(subscription: Subscription): Unit =
-    commonSubscriptionService.updateActivationDate(subscription)
+  def updateActivationDate(subscription: Subscription[Paid]): Unit = {
+    val name = subscription.name
+    subscription.casActivationDate.fold {
+      zuoraService.updateActivationDate(subscription.id)
+    } { date =>
+      logger.debug(s"Activation date already present ($date) in subscription $name")
+      Future.successful(())
+    }
   }
-
+}

--- a/src/main/scala/com/gu/subscriptions/cas/service/api/SubscriptionService.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/service/api/SubscriptionService.scala
@@ -1,15 +1,16 @@
 package com.gu.subscriptions.cas.service.api
 
-import com.gu.memsub.Subscription
 import com.gu.memsub.Subscription.Name
+import com.gu.memsub.subsv2.Subscription
+import com.gu.memsub.subsv2.SubscriptionPlan.Paid
 
 import scala.concurrent.Future
 
 trait SubscriptionService {
 
-  def updateActivationDate(subscription: Subscription): Unit
+  def updateActivationDate(subscription: Subscription[Paid]): Unit
 
-  def getValidSubscription(subscriptionName: Name, password: String) : Future[Option[Subscription]]
+  def getValidSubscription(subscriptionName: Name, password: String) : Future[Option[Subscription[Paid]]]
 
   def isReady: Boolean
 }


### PR DESCRIPTION
- Updated CAS Proxy to use new v2 Membership Common service classes, this makes it compatible once the old v1 classes get deleted.
- Added a weak test to the ProxyDirectiveSpec to also check that paper subs with a Digital Pack charge line also get approved if the 'password' is correct.

cc  @jacobwinch @johnduffell @pvighi @mario-galic