### PR TITLE
update membership common

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.50",
-    "com.gu" %% "membership-common" % "0.293",
+    "com.gu" %% "membership-common" % "0.312",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
@@ -1,11 +1,11 @@
 package com.gu.subscriptions.cas.directives
 
 import akka.testkit.TestProbe
-import com.gu.i18n.GBP
+import com.gu.i18n.Currency.GBP
 import com.gu.memsub.Subscription.{Name, ProductRatePlanId, RatePlanId}
 import com.gu.memsub._
-import com.gu.memsub.subsv2.SubscriptionPlan.{Digipack, Paid, Paper}
-import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, PaperCharges}
+import com.gu.memsub.subsv2.SubscriptionPlan.{Digipack, Paid}
+import com.gu.memsub.subsv2.{PaidCharge, PaidSubscriptionPlan, PaperCharges, ReaderType}
 import com.gu.subscriptions.cas.model.json.ModelJsonProtocol._
 import com.gu.subscriptions.cas.model.{ExpiryType, SubscriptionExpiration, SubscriptionRequest}
 import com.gu.subscriptions.cas.service.api.SubscriptionService
@@ -60,7 +60,7 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
     end = today.plusYears(1)
   )
 
-  private val plusPaperPackageSubscriptionPlan: Paper = PaidSubscriptionPlan[Product.Voucher, PaperCharges](
+  private val plusPaperPackageSubscriptionPlan = PaidSubscriptionPlan[Product.Voucher, PaperCharges](
     id = RatePlanId("5678"),
     name = "Everyday+",
     productRatePlanId = ProductRatePlanId("456"),
@@ -88,7 +88,8 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
     promoCode = None,
     isCancelled = false,
     hasPendingFreePlan = false,
-    plan = digipackSubscriptionPlan
+    plan = digipackSubscriptionPlan,
+    ReaderType.Direct
   )
 
   private val validSubscription2 = validSubscription1.copy(plan = plusPaperPackageSubscriptionPlan)

--- a/src/test/scala/com/gu/subscriptions/cas/model/ContactOpsSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/model/ContactOpsSpec.scala
@@ -6,7 +6,8 @@ import ContactOps.WithMatchingPassword
 
 class ContactOpsSpec extends FlatSpec with Matchers {
   behavior of "ContactOps.matchesPassword"
-  def contact(postcode: String = "123") = Contact("id", "FirstName", "LastName", Some(postcode))
+
+  def contact(postcode: String = "123") = Contact("id", "FirstName", "LastName", Some(postcode), None)
 
   it should "ignore case of either arguments" in {
     contact("N1 9GU").matchesPassword("n1 9gu") should be(true)


### PR DESCRIPTION
Im not very familiar with this project but it  loads the catalog on startup and logs an error if guardian weekly 1 year is defined. I'm not sure if that breaks anything.

I tested doing the same post the runscope test is doing but I'm not sure how much more testing we need for this since this update is bringing a few other changes  in addition to mine
@paulbrown1982 
