### PR TITLE
Use an ACM cert, now we no longer need a .guardian.co.uk cert on the ELB

### DIFF
--- a/cloudformation/content-authorisation-proxy.cf.json
+++ b/cloudformation/content-authorisation-proxy.cf.json
@@ -39,15 +39,6 @@
             "Type": "String"
         }
     },
-    "Mappings": {
-        "CollectorDomainName": {
-            "PROD": {
-                "HostedZoneName": "subscriptions.guardianapis.com.",
-                    "DomainName": "cas-proxy.subscriptions.guardianapis.com.",
-                "CertificateName": "sites.guardian.co.uk"
-            }
-        }
-    },
     "Resources" : {
 
         "CASProxyAutoScalingGroup" : {
@@ -185,7 +176,7 @@
                     "LoadBalancerPort": "443",
                     "InstancePort": 9300,
                     "Protocol": "HTTPS",
-                    "SSLCertificateId" : { "Fn::Join" : [ "", [ "arn:aws:iam::", {"Ref":"AWS::AccountId"}, ":server-certificate/", { "Fn::FindInMap": ["CollectorDomainName", {"Ref": "Stage" }, "CertificateName"]} ] ] }
+                    "SSLCertificateId" : "arn:aws:acm:eu-west-1:865473395570:certificate/4055df40-9561-423c-962b-f78f3ce70434"
                 }],
                 "SecurityGroups" : [ { "Ref" : "LoadBalancerSecurityGroup" } ],
                 "Subnets" : { "Ref" : "Subnets" },
@@ -231,9 +222,9 @@
         "CASProxyELBDNSrecord" : {
             "Type" : "AWS::Route53::RecordSet",
             "Properties" : {
-                "HostedZoneName" : { "Fn::FindInMap": ["CollectorDomainName", {"Ref": "Stage" }, "HostedZoneName"]},
+                "HostedZoneName" : "subscriptions.guardianapis.com.",
                 "Comment" : "CNAME for AWS ELB",
-                "Name" :  { "Fn::FindInMap": ["CollectorDomainName", {"Ref": "Stage" }, "DomainName"]},
+                "Name" :  "cas-proxy.subscriptions.guardianapis.com.",
                 "Type" : "CNAME",
                 "TTL" : "120",
                 "ResourceRecords" : [ {"Fn::GetAtt":["CASProxyElasticLoadBalancer","DNSName"]} ]


### PR DESCRIPTION
The `sites.guardian.co.uk` Comodo cert was due to expire on 7th January 2017, so we needed to update the cert. Rather than renewing, we've CNAME'd `content-auth.guardian.co.uk` to Fastly - so Mobile Apps are now hitting https://content-auth.guardian.co.uk/sub on Fastly which has a valid SSL cert for that domain.

As for the ELB (which is [accessed as cas.subscriptions.guardianapis.com by Fastly](https://manage.fastly.com/configure/services/4k4rlHD5JDSJjvs4K1iQmW/diff/3,4)), this change updates it to use an [ACM cert for *.subscriptions.guardianapis.com](https://eu-west-1.console.aws.amazon.com/acm/home?region=eu-west-1#/?id=4055df40-9561-423c-962b-f78f3ce70434).

This cloud-formation has already been applied, and all [Runscope tests](https://www.runscope.com/radar/f862w29p8z5f) are green:

![image](https://cloud.githubusercontent.com/assets/52038/21428580/a1631d58-c852-11e6-9b9e-fb462dcae799.png)

![image](https://cloud.githubusercontent.com/assets/52038/21428330/61adba3e-c851-11e6-82bf-e38f5aaf29ef.png)

cc @paulbrown1982


