### PR TITLE
Update membership common version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.50",
-    "com.gu" %% "membership-common" % "0.312",
+    "com.gu" %% "membership-common" % "0.353",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/src/main/scala/com/gu/subscriptions/cas/bootstrap/Bootstrap.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/bootstrap/Bootstrap.scala
@@ -30,7 +30,7 @@ object Bootstrap extends App {
   val catalogService = new CatalogService[Future](newProductIds, Rest.simpleClient, Await.result(_, 10.seconds), stage)
 
   private val map = this.catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
-  val commonSubscriptionService = new CommonSubscriptionService[Future](newProductIds, map, Rest.simpleClient, zuoraService.getAccountIds, () => LocalDate.now)
+  val commonSubscriptionService = new CommonSubscriptionService[Future](newProductIds, map, Rest.simpleClient, zuoraService.getAccountIds)
   val subscriptionService = new SubscriptionService(zuoraService, commonSubscriptionService)
   val service = system.actorOf(Props(classOf[CASService], subscriptionService))
 

--- a/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
@@ -29,7 +29,6 @@ object Zuora {
   }
 
   val cloudWatch = new CloudWatch {
-    override val region: Region = Region.getRegion(Regions.EU_WEST_1)
     override val application: String = appName
     override val service: String = "ZuoraSubscriptionService"
     override val stage: String = Configuration.stage

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
@@ -20,6 +20,7 @@ import spray.routing.{HttpService, Route}
 import spray.testkit.ScalatestRouteTest
 
 import scala.concurrent.Future
+import scalaz.NonEmptyList
 
 class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDirective with HttpService {
 
@@ -88,11 +89,12 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
     promoCode = None,
     isCancelled = false,
     hasPendingFreePlan = false,
-    plan = digipackSubscriptionPlan,
-    ReaderType.Direct
+    plans = NonEmptyList(digipackSubscriptionPlan),
+    readerType = ReaderType.Direct,
+    autoRenew = true
   )
 
-  private val validSubscription2 = validSubscription1.copy(plan = plusPaperPackageSubscriptionPlan)
+  private val validSubscription2 = validSubscription1.copy(plans = NonEmptyList(plusPaperPackageSubscriptionPlan))
 
   override lazy val subscriptionService = new SubscriptionService {
 


### PR DESCRIPTION
This PR pulls in the latest membership common version, which allows CAS to 'understand' Subs with a 'Semi_Annual' billing period.

It turns out that @pvighi already added the concept of a ZBillingPeriod (which includes 'Semi_Annual') to SubJsonReads (in https://github.com/guardian/membership-common/pull/367). 

I've tested that CAS still responds correctly to a standard Digipack sub, and am also able to successfully lookup a migrated Voucher+ sub with a Semi_Annual billing period, so bumping the membership-common version seems to be sufficient for a short-term fix.

@paulbrown1982 