### PR TITLE
use membership common that understands frontend ids

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.50",
-    "com.gu" %% "membership-common" % "0.353",
+    "com.gu" %% "membership-common" % "0.359",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ libraryDependencies ++= {
     "net.kencochrane.raven" % "raven-logback" % "6.0.0",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.10.50",
-    "com.gu" %% "membership-common" % "0.359",
+    "com.gu" %% "membership-common" % "0.360",
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
   )
 }

--- a/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
+++ b/src/test/scala/com/gu/subscriptions/cas/directives/ProxyDirectiveSpec.scala
@@ -55,7 +55,7 @@ class ProxyDirectiveSpec extends FreeSpec with ScalatestRouteTest with ProxyDire
     productName = "Digital Pack",
     product = Product.Digipack,
     features = List.empty,
-    charges = PaidCharge(Digipack, BillingPeriod.year, PricingSummary(Map(GBP -> Price(119.90f, GBP)))),
+    charges = PaidCharge(Digipack, BillingPeriod.Year, PricingSummary(Map(GBP -> Price(119.90f, GBP)))),
     chargedThrough = Some(today),
     start = today,
     end = today.plusYears(1)


### PR DESCRIPTION
https://github.com/guardian/membership-common/pull/419 understand free id
edit:
guardian/membership-common#424 don't read the untagged rateplans
guardian/membership-common#425 use billing period as an object not a case class