### PR TITLE
set ttl timestamp in seconds since epoch instead of mills

### DIFF
--- a/src/main/scala/com/gu/subscriptions/cas/service/DataStore.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/service/DataStore.scala
@@ -48,7 +48,7 @@ class DataStore(implicit ec: ExecutionContext) extends api.DataStore {
 
   override def setExpiration(appId: String, deviceId: String, expiration: LocalDate, timeToLive: ReadablePeriod): Future[SetExpirationResponse] = {
 
-    val ttlTimestamp = DateTime.now.plus(timeToLive).getMillis
+    val ttlTimestamp = DateTime.now.plus(timeToLive).getMillis / 1000
     val newItem = AuthItem(appId, deviceId, expiration, Some(ttlTimestamp))
 
     ScanamoAsync.exec(dynamoClient)(authTable.put(newItem)).map(a => api.Success)


### PR DESCRIPTION
the dynamo table that holds auth data is configured to clean up entries automatically according to the ttlTimestamp attribute [dynamo TTL feature doc](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/howitworks-ttl.html).

The value was set in milliseconds since the unix epoch but amazon expects it to be in seconds since the epoch, which makes the first item to be cleaned from the table around the year 50210.

This fixes it so that we set the ttl in the correct format. A script will be run to fix the existing data in the table.

@johnduffell @AWare @jacobwinch @paulbrown1982 @lmath 