### PR TITLE
Use Encrypted dynamo table

### DIFF
--- a/cloudformation/content-authorisation-proxy.cf.yaml
+++ b/cloudformation/content-authorisation-proxy.cf.yaml
@@ -167,7 +167,7 @@ Resources:
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem
             - dynamodb:BatchGetItem
-            Resource: !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/daily-edition-trials-${Stage}'
+            Resource: !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/daily-edition-trial-periods-${Stage}'
       - PolicyName: PushMetrics
         PolicyDocument:
           Version: '2012-10-17'

--- a/cloudformation/content-authorisation-proxy.cf.yaml
+++ b/cloudformation/content-authorisation-proxy.cf.yaml
@@ -156,7 +156,7 @@ Resources:
             - dynamodb:DeleteItem
             - dynamodb:BatchGetItem
             Resource: !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/cas-auth-${Stage}'
-   - PolicyName: dynamoTable
+      - PolicyName: dynamoTable
         PolicyDocument:
           Version: '2012-10-17'
           Statement:

--- a/cloudformation/content-authorisation-proxy.cf.yaml
+++ b/cloudformation/content-authorisation-proxy.cf.yaml
@@ -144,7 +144,7 @@ Resources:
             - logs:*
             Resource:
             - arn:aws:logs:*:*:*
-      - PolicyName: dynamoTable
+      - PolicyName: unEncryptedDynamoTable
         PolicyDocument:
           Version: '2012-10-17'
           Statement:
@@ -156,6 +156,18 @@ Resources:
             - dynamodb:DeleteItem
             - dynamodb:BatchGetItem
             Resource: !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/cas-auth-${Stage}'
+   - PolicyName: dynamoTable
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - dynamodb:PutItem
+            - dynamodb:GetItem
+            - dynamodb:UpdateItem
+            - dynamodb:DeleteItem
+            - dynamodb:BatchGetItem
+            Resource: !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/daily-edition-trials-${Stage}'
       - PolicyName: PushMetrics
         PolicyDocument:
           Version: '2012-10-17'

--- a/src/main/resources/DEV.public.conf
+++ b/src/main/resources/DEV.public.conf
@@ -1,4 +1,4 @@
 include "touchpoint.DEV"
 stage = "DEV"
 
-dynamo.auth.table = "cas-auth-CODE"
+dynamo.auth.table = "daily-edition-trial-periods-CODE"

--- a/src/main/resources/PROD.public.conf
+++ b/src/main/resources/PROD.public.conf
@@ -2,4 +2,4 @@ include "touchpoint.PROD"
 
 stage = "PROD"
 
-dynamo.auth.table = "cas-auth-PROD"
+dynamo.auth.table = "daily-edition-trial-periods-PROD"


### PR DESCRIPTION
the encrypted dynamo table daily-edition-trial-periods-PROD is already created and populated with all the data that was in CAS-auth-PROD as of this morning around 10:46.
The people we miss in the switch from one table to the other would just get a new trial period so worst case scenario they get one extra day in their trial period.

We will remove the unencrypted dynamodb table when we are confident that we will not need to back to it