### PR TITLE
Wait patiently whilst fetching the catalog

### DIFF
--- a/src/main/scala/com/gu/subscriptions/cas/bootstrap/Bootstrap.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/bootstrap/Bootstrap.scala
@@ -27,7 +27,7 @@ object Bootstrap extends App {
   private val newProductIds = productIds(stage)
 
   val zuoraService = new ZuoraService(Soap.client)
-  val catalogService = new CatalogService[Future](newProductIds, Rest.simpleClient, Await.result(_, 10.seconds), stage)
+  val catalogService = new CatalogService[Future](newProductIds, Rest.patientClient, Await.result(_, 60.seconds), stage)
 
   private val map = this.catalogService.catalog.map(_.fold[CatalogMap](error => {println(s"error: ${error.list.mkString}"); Map()}, _.map))
   val commonSubscriptionService = new CommonSubscriptionService[Future](newProductIds, map, Rest.simpleClient, zuoraService.getAccountIds)

--- a/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
+++ b/src/main/scala/com/gu/subscriptions/cas/config/Zuora.scala
@@ -25,5 +25,6 @@ object Zuora {
     val apiConfig = ZuoraApiConfig.rest(touchpointConfig, appStage)
     val metrics = new ServiceMetrics(appStage, appName, "zuora-rest-client")
     val simpleClient = new rest.SimpleClient[Future](apiConfig, futureRunner)
+    val patientClient = new rest.SimpleClient[Future](apiConfig, configurableFutureRunner(60.seconds))
   }
 }


### PR DESCRIPTION
## Why are you doing this?
A recent incident with members-data-api alerted us to a potential risk concerning the startup for this app. If the catalog cannot be loaded on startup, a failed future is kept, which causes errors downstream. This is a quick fix to decrease the likelihood of the request to get the catalog failing.

## Changes
* Use a 60 second timeout when loading the catalog.